### PR TITLE
Fix markup

### DIFF
--- a/extension/index.html
+++ b/extension/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
+	<meta charset="utf-8"/>
 	<head>
 		<title>Cognitive and Learning Disabilities and WCAG</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
@@ -791,7 +792,7 @@ In menus :
 			</ul>
 	</section>
 		<section>
-			<h2 id="changedlevels>Items where WCAG 2.0 SC levels should be changed</h2>
+			<h2 id="changedlevels">Items where WCAG 2.0 SC levels should be changed</h2>
 			<p>We recommend the following level AAA are considered more important for COGA </p>
 			<ul>
 				<li>1.4.7 Low or No Background Audio No Background: The audio does not contain background sounds or Turn Off: The background sounds can be turned off. </li>


### PR DESCRIPTION
Broken markup is upsetting ReSpec. Also, please consider dropping xhtml (as it's also not helping with catching markup errors). The W3C no longer wishes to publish in that format.