### PR TITLE
Redo cleanup links

### DIFF
--- a/extension/index.html
+++ b/extension/index.html
@@ -173,7 +173,7 @@
               <dt><dfn>essential information</dfn></dt>
               <dd>information that is required by the application to complete the task requested by the used. Clear visual indicator is one that 99% of your <a>target audience</a> understand) </dd>
               
-              <dt><dfn>important information</dfn></dt>
+              <dt><dfn id="dfn-important-information">important information</dfn></dt>
               <dd>
                 <ol>
                   <li>information the user may need to complete any action or task including an offline task. </li>
@@ -182,10 +182,10 @@
                 <p>(COGA Techniques 2.5) </p>
                 </dd>
               
-              <dt><dfn>jargon</dfn></dt>
+              <dt><dfn id="dfn-jargon">jargon</dfn></dt>
               <dd>a type of language that is used in a particular context and may not be well understood outside of it </dd>
               
-              <dt><dfn>keywords that aid comprehension</dfn></dt>
+              <dt><dfn id="dfn-keywords-that-aid-comprehension">keywords that aid comprehension</dfn></dt>
               <dd>definition</dd>
               
               <dt><dfn>known techniques</dfn></dt>
@@ -203,7 +203,7 @@
               <dt><dfn>non-trivial information</dfn></dt>
               <dd>Information the user may find important or need to know , such as infromation that the user may have searched to find. <span class="ednote">- coment - may be to vage. information can be non trivial but noone NEEDS to know it </span></dd>
               
-              <dt><dfn>personalization</dfn></dt>
+              <dt><dfn id="dfn-personalization">personalization</dfn></dt>
               <dd>User interface that is driven by the individual user's preferences.</dd>
               
               <dt><dfn>rapid feedback</dfn></dt>
@@ -237,7 +237,7 @@
                   </ol>
                 </dd>
               
-              <dt><dfn>standardized APIs</dfn></dt>
+              <dt><dfn id="dfn-standardized-APIs">standardized APIs</dfn></dt>
               <dd>identified in the platform's documentation or in a WCAG technique or W3C publication</dd>
               
               <dt><dfn>target audience</dfn></dt>

--- a/gap-analysis/table.html
+++ b/gap-analysis/table.html
@@ -19,7 +19,7 @@ table {border:thin; border-style:groove;}
 <ul>
   <li>Each row starts, in the first column, with user needs to be addressed.</li>
   <li><a id="WCAGex" ></a>The second column in each row describes how user needs could be addressed in the next version of the WCAG. It gives the names of the relevant success criteria proposals. For the full text, see  current at <a rel="nofollow" href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/SC_To Do_list">WCAG  COGA SC and To Do List</a></li>
-  <li><a id="authoring" ></a>The third column describes examples of authoring techniques that may support user needs or WCAG success criteria. See the <a rel="nofollow" href="https://rawgit.com/w3c/COGA/master/techniques/index.html">COGA authoring techniques document</a> or the appendix on making content accessible for people with learning and cognitive disabilities.</li>
+  <li><a id="authoring" ></a>The third column describes examples of authoring techniques that may support user needs or WCAG success criteria. See the <a rel="nofollow" href="https://w3c.github.io/coga/techniques/index.html">COGA authoring techniques document</a> or the appendix on making content accessible for people with learning and cognitive disabilities.</li>
   <li><a id="semantics" ></a> The fourth column describes new semantics that may be required to address user needs, such as extra ARIA attributes. See the draft for <a rel="nofollow" href="https://www.w3.org/TR/personalization-semantics-1.0/">Personalization Semantics</a> (that may become a WAI-ARIA [[wai-ARIA]] module); and personalization syntax and vocabulary to enable adaptable interfaces. </li>
   <li><a id="personalization" ></a>The fifth column describes any personalization requirements. </li>
   <li><a id="operating" ></a>The last column describes operating system support or other support that may be required to meet user needs.</li>
@@ -61,7 +61,7 @@ table {border:thin; border-style:groove;}
         <p>--------</p>
         <p><strong>Editors' Note:</strong> does this support symbol users?</p>
         </td>
-      <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Minimizethecognitiveskills"> Minimize the cognitive skills required to use the content</a> - the examples in security.</p>
+      <td><p><a href="https://w3c.github.io/coga/techniques/index.html#Minimizethecognitiveskills"> Minimize the cognitive skills required to use the content</a> - the examples in security.</p>
         <p>Techniques should include how to have security that uses passwords or transcribing, such as biometrics and tokens.</p></td>
       <td>None</td>
       <td><p><strong>Editors' Note:</strong> we need to capture types of security these users can employ and, maybe, if they require the use of an API such as password storage.</td>
@@ -81,7 +81,7 @@ table {border:thin; border-style:groove;}
         <p>and</p>
         <p><strong>Do not automatically choose options that may disadvantage users</strong> without their approval, or add mechanisms likely to confuse users in a way that may do them harm.</p>
         <p>Level A</p>
-        <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#keep-the-user-safe"> Keep users safe</a>.</p>
+        <td><p><a href="https://w3c.github.io/coga/techniques/index.html#keep-the-user-safe"> Keep users safe</a>.</p>
         
         <p><strong>Editors' Note:</strong> add notify users when they are leaving a website if leaving it may cause them harm.</p>
         <p>Give positive and negative examples.</p></td>
@@ -93,12 +93,12 @@ table {border:thin; border-style:groove;}
   </tbody>
 </table>
 				<h4 id="Discussion1">Discussion</h4>
-                <p><a href="https://rawgit.com/w3c/COGA/master/issue-papers/privacy-security.html">Privacy and Security issue paper</a><a href="https://rawgit.com/w3c/COGA/master/issue-papers/security.html"></a></p>
-                <p><a href="https://rawgit.com/w3c/COGA/master/issue-papers/safety.html">Online Safety issue paper</a></p>
+                <p><a href="https://w3c.github.io/coga/issue-papers/privacy-security.html">Privacy and Security issue paper</a><a href="https://w3c.github.io/coga/issue-papers/security.html"></a></p>
+                <p><a href="https://w3c.github.io/coga/issue-papers/safety.html">Online Safety issue paper</a></p>
                 <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Easy_Personalization">Script for Personalization</a> and <a href="https://github.com/ayelet-seeman/COGA.personalisation">example for personalization</a></p>
                 <p><a href="https://www.w3.org/TR/personalization-semantics-1.0/">Semantics</a></p>
                 <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Proposal_for_WCAG ">Proposal for WCAG </a></p>
-                <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html ">Techniques</a></p>
+                <p><a href="https://w3c.github.io/coga/techniques/index.html ">Techniques</a></p>
   
 </section>
 <section>
@@ -130,7 +130,7 @@ table {border:thin; border-style:groove;}
 				        <p>--------</p>
 				        <p><strong>Editors' Note:</strong> this was accepted into WCAG 2.1 at level AAA.</p>
 			          </td>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">Attention and Focus</a></span></p>
+				      <td><p><a href="https://w3c.github.io/coga/techniques/index.html#attention-and-focus">Attention and Focus</a></span></p>
 			          </td>
 				      <td>
 				        <p><strong>Proposed attribute: </strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#distraction-explanation">aui-distraction</a></p>
@@ -183,7 +183,7 @@ table {border:thin; border-style:groove;}
 				      <td><p>As above.</p>
 			          <p>(See: A clear navigational path is provided for all content that: )</p></td>
 				      <td><p>As above</p>
-			            <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost" id="help-the-user-orient-themselves-and-regain-focus-when-it-is-lost2"><span property="xhv:role" resource="xhv:heading">Help users orient themselves and regain focus when it is lost.</span></p>
+			            <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost" id="help-the-user-orient-themselves-and-regain-focus-when-it-is-lost2">Help users orient themselves and regain focus when it is lost.</p>
 		              </td>
 				      <td></td>
 				      <td></td>
@@ -193,7 +193,7 @@ table {border:thin; border-style:groove;}
 				      <th scope="row"><p>I need to restore context in multimedia. I need to go back to that bit I just missed, or reorient myself if I lost context.</p>
 			          <p>(Assume I have an attention disability and/or an impaired short-term memory.)</p></th>
 				      <td>As above.</td>
-				      <td><span property="xhv:role" resource="xhv:heading">Help users orient themselves and  regain focus when it is lost.</span>
+				      <td>Help users orient themselves and  regain focus when it is lost.
 			            <p>For multimedia,  provide  labels for sections such that the labels can  provide an outline of the content.<br />
 			              For multimedia, users can directly navigate to each section of the content.<br />
 			              Unique <br />
@@ -237,7 +237,7 @@ table {border:thin; border-style:groove;}
 			          
 			          <p><strong>Support  personalization.</strong></p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#alow-the-user-to-determine-levels-of-interruptions-as-easily-as-possible">Enable users to determine levels of interruptions as easily as possible.</a></span>
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#alow-the-user-to-determine-levels-of-interruptions-as-easily-as-possible">Enable users to determine levels of interruptions as easily as possible.</a>
 				      	<p></p></td>
 				      <td><p>As above.</p>
                       <p></p></td>
@@ -263,7 +263,7 @@ table {border:thin; border-style:groove;}
                         <li>non-critical messages that can easily be turned off and on again.</li>
                       </ul>
                       </td>
-				      <td><p><a href="https://rawgit.com/w3c/COGA/master/issue-papers/distractions.html">Operating System Tool</a></p>
+				      <td><p><a href="https://w3c.github.io/coga/issue-papers/distractions.html">Operating System Tool</a></p>
 			          <p></p>
 			          <p>See Integrated solution.</p>
 			          <p> It is based on a matrix for distractions at the operating system,   browser, or cloud level. Users can turn off  distractions, such   as Skype  and Facebook, across different devices, and then may forget   to turn them back on. This idea manages all distractions by forming a   cross-application and cross-device distraction matrix that manages all   distractions in one setting.</p></td>
@@ -271,12 +271,12 @@ table {border:thin; border-style:groove;}
 			      </tbody>
 			  </table>
   <h4 id="Discussion3">Discussion</h4>
-    <p><a  href="https://rawgit.com/w3c/COGA/master/issue-papers/distractions.html">Distractions issue paper</a></p>
+    <p><a  href="https://w3c.github.io/coga/issue-papers/distractions.html">Distractions issue paper</a></p>
     <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Easy_Personalization">Script for personalization</a> and
     <a href="https://github.com/ayelet-seeman/COGA.personalisation">Example for personalization</a></p>
     <p><a href="https://www.w3.org/TR/personalization-semantics-1.0/">Semantics</a></p>
     <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Proposal_for_WCAG ">Proposal for WCAG </a></p>
-    <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html ">Techniques</a></p>
+    <p><a href="https://w3c.github.io/coga/techniques/index.html ">Techniques</a></p>
     
 </section>
 			<section>
@@ -324,9 +324,9 @@ table {border:thin; border-style:groove;}
 				        <p><strong>Undo</strong></p>
 				        <p><strong>Editors' Note:</strong> change to 3.3.4 Error Prevention.</p>
                         <p><strong>Safe</strong></p>
-                        <p><span property="xhv:role" resource="xhv:heading">and</span></p>
+                        <p>and</p>
                         <p><strong>3.3.5 Help: (AA)</strong></p>
-                        <p>Provided content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
+                        <p>Provided content and information that help users understand <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                         <p>Where an understanding of math is not a primary   requirement for using content, reinforce numbers with non-numerical   values. </p>
                         <p>Simple search forms are excluded (context-sensitive help as technique).</p>
                         
@@ -341,16 +341,16 @@ table {border:thin; border-style:groove;}
 				        <p>AA - provide  beginner help, and easy access to human help, on forms and interactive controls for critical services.</p>
 				        
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">Prevent Errors</a></span>
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#prevent-errors">Prevent Errors</a>
 			          <p resource="#prevent-errors">..</p>
-<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">Provide Help</a></span>
+						<a href="https://w3c.github.io/coga/techniques/index.html#provide-help">Provide Help</a>	
 			          
 			          <p resource="#provide-help">..</p>
 			          <p resource="#prevent-errors"> COGA Techniques 2.7:  aui-explain to explain any nonstandard UI where they cannot be.</p></td>
 				      <td> <strong>Explain and feedback</strong>
 				      	<p></p>
 
-<span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
+<strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong>
 		              <p>Standardize supportive syntax and terms that can be linked, for users, to associated   symbols, terms, translations, and explanations.</p>
 		              <p></p>
 		              
@@ -416,15 +416,15 @@ Always    open</p>
 			        </tr>
 				    <tr>
 				      <th scope="row">I need to know what mistake I made and how to correct a mistake. It does not cause undue alarm when I make a mistake and can correct it easily. </th>
-				      <td><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option"> Provide Feedback</a></strong>
+				      <td><strong><a href="https://w3c.github.io/coga/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option"> Provide Feedback</a></strong>
 			            <p></p>
-			          <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#support">Undo</a></strong></p>
+			          <p><strong><a href="https://w3c.github.io/coga/extension/index.html#support">Undo</a></strong></p>
 			          <p>A simple mechanism is provided to enable users to undo mistakes. Users can repair information via clearly-labeled actions. Users can get back to   the place they were at in one clearly-labeled action with unwanted loss   of data. </p>
 			          <p></p>
 			          <p><strong>Editors' Note:</strong> also covered in WCAG in 3.3.1.</p>
 			          <p><strong>Editors' Note:</strong> making error-message text understandable is covered in WCAG in
                       <strong>Understandable language</strong>.</p>
-                      <p><span><em><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Instructions, labels, navigation ..</a></em></span>
+                      <p><span><em><a href="https://w3c.github.io/coga/extension/index.html#instructions">Instructions, labels, navigation ..</a></em></span>
                       </p>
                       <p></p>
 			          <p><strong>Editors' Note:</strong> also see WCAG 3.3.4 Error Prevention (Legal, Financial, Data) (financial legal and user data) and 3.3.6 (All).</p>
@@ -435,9 +435,9 @@ Always    open</p>
 			          
 			          
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes.</a></span>
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes.</a>
 			          <p resource="#make-it-easy-to-undo-mistakes"></p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#explain-explanation">Explain</a> and <a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">Feedback</a></span>
+				      <td><a href="https://w3c.github.io/personalization-semantics/help/index.html#explain-explanation">Explain</a> and <a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">Feedback</a>
                         <p></p>
                         
                         <p><strong>Editors' Note:</strong> change feedback to a role.</p>
@@ -482,13 +482,13 @@ Always    open</p>
 			        </tr>
 				    <tr>
 				      <th scope="row">I need enough time, and  not lose my work. </th>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#timed">Changes to timed events</a></strong>.</span>
+				      <td><strong><a href="https://w3c.github.io/coga/extension/index.html#timed">Changes to timed events</a></strong>.
 		                <p ></p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-users-complete-and-check-their-work">Help users complete and check their work</a>.</span>				        
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#help-users-complete-and-check-their-work">Help users complete and check their work</a>.			        
 				        <p resource="#provide-help"></p>
-<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#enough-time">Enough Time</a></span>
+<a href="https://w3c.github.io/coga/techniques/index.html#enough-time">Enough Time</a>
                       <p resource="#enough-time"></p>
-<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#avoid-loss-of-data">Avoid Loss of data</a>.</span>
+<a href="https://w3c.github.io/coga/techniques/index.html#avoid-loss-of-data">Avoid Loss of data</a>.
                       <p resource="#avoid-loss-of-data"></p>
                       </td>
 				      <td></td>
@@ -499,9 +499,9 @@ Always    open</p>
 			        </tr>
 				    <tr>
 				      <th scope="row"><p>I want to use applications or APIs that help me, such as remembering my information so I do not need to enter it again, and to help me (such as spelling).</p></th>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><strong>Help</strong></span></p>
+				      <td><p><strong>Help</strong></p>
 				        
-<a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-standardized-APIs">Support APIs</a> (may change)                      
+<a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-standardized-APIs">Support APIs</a> (may change)                      
 <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes">..</h4></td>
 				      <td><p>Avoid form autocomplete="off"</p>
 			          
@@ -519,9 +519,9 @@ Always    open</p>
 				        <p>(Text: The main purpose of each page and section of content is clear. Extraneous information, not directly relevant to the main purpose of a page, is distinctly separated and programmatically determinable. For multi-step tasks, signposts should be provided to clarify the broader context, including steps completed, current step, and pending steps.)</p>
 				        
 				        <p>See also:</p>
-                      <p><span property="xhv:role" resource="xhv:heading"> <strong>Clear structure </strong></span> and relationships</p>
+                      <p><strong>Clear structure </strong> and relationships</p>
                       <p><strong>Help</strong>:</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-the-user-orientate-themselves-and-regain-focus-when-it-is-lost">Help users orient themselves, and regain focus when it is lost</a>.</span>
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#help-the-user-orientate-themselves-and-regain-focus-when-it-is-lost">Help users orient themselves, and regain focus when it is lost</a>.
 				        <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost"></p>
 			          <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">..</p></td>
 				      <td><p>LOG</p>
@@ -552,7 +552,7 @@ Always    open</p>
 			          <p><strong>Help</strong></p>
 			          <p>Change to timed events. </p>
 			          <p>The timeframe for reversing transactions is machine  readable.</p></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes</a>.</span></p>
+				      <td><p><a href="https://w3c.github.io/coga/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes</a>.</p>
                         <p></p>
                       <p></p></td>
 				      <td><p>Log</p>
@@ -592,7 +592,7 @@ Always    open</p>
                 <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Easy_Personalization">Script for Personalization</a> and <a href="https://github.com/ayelet-seeman/COGA.personalisation">Example for personalization</a></p>
                 <p><a href="https://www.w3.org/TR/personalization-semantics-1.0/">Semantics</a></p>
                 <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Proposal_for_WCAG ">Proposal for WCAG </a></p>
-                <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html ">Techniques</a></p>
+                <p><a href="https://w3c.github.io/coga/techniques/index.html ">Techniques</a></p>
                 
 </section>
 			<section>
@@ -630,7 +630,7 @@ Always    open</p>
 				      <th scope="row"><p>I need more explanations, such as  context sensitive help and short tips.</p>
 				         <p> <a href="#Discussion7">more</a> </p></th>
 				      <td><p id="provided_content"><strong>3.3.5 Help:</strong> (AA)</p>
-                        <p>Provide content and information that help users understand. <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
+                        <p>Provide content and information that help users understand. <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                         <p>Where an understanding of math is not a primary   requirement for using content, reinforce numbers with non-numerical   values. </p>
                         <p>Simple search forms are excluded.</p>
                         
@@ -644,14 +644,14 @@ Always    open</p>
 				        <p>Level A</p>
 				        
 			          </td>
-				      <td><p resource="#provide-help"> COGA Techniques 2.7:  <span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">Prevent Errors</a>.</span> </p>
+				      <td><p resource="#provide-help"> COGA Techniques 2.7:  <a href="https://w3c.github.io/coga/techniques/index.html#prevent-errors">Prevent Errors</a>. </p>
                       <p resource="#prevent-errors">..</p>
-                      <span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">Provide Help</a>.</span>
+                      <a href="https://w3c.github.io/coga/techniques/index.html#provide-help">Provide Help</a>.
                       <p resource="#provide-help">..</p>
                       <p resource="#prevent-errors"> COGA Techniques 2.7 </p>
                       <p>For icons and jargon:</p>
                       <ul>
-                        <li> All icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> have short explanations available where a standard mechanism exists   for the platform or technologies in which it should be used.</li>
+                        <li> All icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> have short explanations available where a standard mechanism exists   for the platform or technologies in which it should be used.</li>
                       </ul>
                       
                       <p>For  forms and nonstandard controls:</p>
@@ -665,10 +665,10 @@ Always    open</p>
                       <p resource="#prevent-errors">..</p>
                       <p resource="#prevent-errors"><strong>Editors' Note:</strong> check that the way  sufficient techniques are done really meet the use cases.</p></td>
 				      <td>
-				        <span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
+				        <strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong>
 				        <p>Standardize supportive syntax and terms that can be linked to associated   symbols, terms, translations, and explanations for users. </p>
 				        <p></p>
-				        <p><span property="xhv:role" resource="xhv:heading"><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></strong></span></p>
+				        <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></strong></p>
 			          <p resource="#h-more-help"></p></td>
 				      <td>See help personalization in table above.</td>
 				      <td></td>
@@ -676,7 +676,7 @@ Always    open</p>
 				    <tr>
 				      <th scope="row"><p>I know how to get more information.</p>
 			          <p> <a href="#Discussion7">more</a> </p></th>
-				      <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support Personalization</a>.</strong></p>
+				      <td><p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support Personalization</a>.</strong></p>
 					     <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
                         <p></p>
@@ -690,8 +690,8 @@ Always    open</p>
 				        
 				        
 				        
-				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Support is provided that helps users understand the content</a>, which includes:</span> </p>
-				        <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes2"><span property="xhv:role" resource="xhv:heading"><span typeof="bookmark"></span></span></h4>
+				        <p><a href="https://w3c.github.io/coga/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Support is provided that helps users understand the content</a>, which includes: </p>
+				        
 				        <p>Level A</p>
 				        <p>--------</p>
 				        <p>a familiar interface to identify help and contact us;</p>
@@ -701,10 +701,10 @@ Always    open</p>
 				      <td><p resource="#prevent-errors">..</p></td>
 				      <td> <a href="https://w3c.github.io/personalization-semantics/help/index.html#explain-explanation">Explain</a> and <a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">Feedback</a>
 				        <p></p>
-				        <span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+				        <a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
 				        <p>For users, standardize supportive syntax and terms that can be linked to associated   symbols, terms, translations, and explanations</p>
 				        <p></p>
-				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></span> </p>
+				        <p><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a> </p>
 				        <p resource="#h-more-help">..</p>
 				        <p><strong>Requirement: </strong>Some users may need additional   information, or specifically additional help information. There should be  extra attributes so an author can indicate the existence of additional information.</p>
                         <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#moreinfo-explanation">aui-moreinfo</a></p>
@@ -744,10 +744,10 @@ aui-hidden="true"&gt;</pre>
 	                    
 	                  <p>AAA human help is provided</p>
                       </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">Provide Human Help</a></span>
+				      <td><a  title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#Providehumanhelp">Provide Human Help</a>
 			          <p resource="#Providehumanhelp"></p></span></td>
 				      <td><p resource="#h-more-help">..</p>
-				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></span></p>
+				        <p><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></p>
 				        <p>(see above)</p>
                       <p resource="#h-more-help"></td>
 				      <td></td>
@@ -757,7 +757,7 @@ aui-hidden="true"&gt;</pre>
 				      <th scope="row">I need symbols that help me understand content. </th>
 				      <td><p><strong>Provide content and information that help users understand content.</strong></p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.</span>
+				      <td><a  title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.
 				        <p resource="#h-use-symbols-and-images-to-show-meaning"></p>
 				        
 				        
@@ -769,7 +769,7 @@ aui-hidden="true"&gt;</pre>
 			            </li>
 			          </ul></td>
 				      <td><p resource="#h-more-help">..</p>
-			          <p resource="#h-more-help"><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span> </p>
+			          <p resource="#h-more-help"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a> </p>
 			          
                       <p></p></td>
 				      <td></td>
@@ -778,24 +778,24 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row">I need contextually-relevant graphs and pictures to supplement text so I can understand a point without a lot of reading. </th>
 				      <td><p><strong>3.3.5 Help: (AA)</strong> (changes)</p>
-                        <p>Provide content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
+                        <p>Provide content and information that help users understand <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                         <p>sufficient techniques </p>
                         <h5 id="provided_content5">..</h5>
                         <p>(See COGA Techniques 2.7.) </p>
                         <p>For icons and jargon:</p>
                         <ul>
-                          <li> All icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> have a short explanation available. Where a standard mechanism exists   for a platform or technologies, it should be used. (COGA Techniques 2.7.) (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon,</a> which clarify the meaning, are provided.)</li>
+                          <li> All icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> have a short explanation available. Where a standard mechanism exists   for a platform or technologies, it should be used. (COGA Techniques 2.7.) (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon,</a> which clarify the meaning, are provided.)</li>
                         </ul>
                         <p>For content relating to numbers and complex information:</p>
                         <ul>
-                          <li> Charts or graphics are provided where they aid comprehension of <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a> (COGA Techniques 2.7.3.) </li>
+                          <li> Charts or graphics are provided where they aid comprehension of <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a> (COGA Techniques 2.7.3.) </li>
                         </ul>
                       				        <p resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes">..</p></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><a title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-meaning">Help meaning</a></span></p>
+				      <td><p><a title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#help-meaning">Help meaning</a></p>
 				        <p></p>
-<span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.</span>
+<a  title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.
 			          <p resource="#h-use-symbols-and-images-to-show-meaning"></p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+				      <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                         <p></p>
                       
                       </td>
@@ -804,8 +804,8 @@ aui-hidden="true"&gt;</pre>
 			        </tr>
 				    <tr>
 				      <th scope="row">I need speech support, with synchronized highlighting, so I can follow as I go. </th>
-				      <td><strong>Support known <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-standardized-APIs">standardized APIs</a> for tools that help users understand and use  content. </strong> This includes:</td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-speech-support">Provide Speech Support</a></span>
+				      <td><strong>Support known <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-standardized-APIs">standardized APIs</a> for tools that help users understand and use content. </strong> This includes:</td>
+				      <td><a  title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#provide-speech-support">Provide Speech Support</a>
                       <p resource="#provide-speech-support"></p></td>
 				      <td><p><strong>Editors' Note:</strong> do we need semantics that identify phrases?</p>
 				        
@@ -879,7 +879,7 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row">I do not want too many reminders, as I will be distracted.</th>
 				      <td><strong>Reminders: </strong>Reminders should be set only at users' requests. Users should be   able to personalize the reminder method. Where a standard mechanism   exists for the platform or technologies, it should be used.</td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">Attention and Focus</a></span>
+				      <td><a title="expand" class="expand" aria-label="expand " href="https://w3c.github.io/coga/techniques/index.html#attention-and-focus">Attention and Focus</a>
 			          <p resource="#attention-and-focus"></p></td>
 				      <td><p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/tools/index.html#use_case_reminder">aui-reminder</a></p>
                         <p>Enable users to turn off less-helpful reminders.</p>
@@ -930,15 +930,15 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row"><p>Controls are clear.  </p>
 				        <p> <a href="#Discussion7">more</a> </p></th>
-				      <td> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#controls">clear controls</a></strong>
+				      <td> <strong><a href="https://w3c.github.io/coga/extension/index.html#controls">clear controls</a></strong>
 <p></p>
 				        <p>Level A</p>
 				        <p>--------</p>
 				        <p><strong>Editors' Note:</strong> to add</p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading"><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-clear-visual-affordances">Use clear visual affordances</a>.</span>
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#use-clear-visual-affordances">Use clear visual affordances</a>.
 			          <p></p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
+				      <td><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong>
                         
                       <p></p></td>
 				      <td><p>Identify how to present different roles, elements, and context elements.</p>
@@ -949,7 +949,7 @@ aui-hidden="true"&gt;</pre>
 			        </tr>
 				    <tr>
 				      <th scope="row"></th>
-				      <td><p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#324">A predictable design is used within a set of pages that includes:</a></p>
+				      <td><p><a href="https://w3c.github.io/coga/extension/index.html#324">A predictable design is used within a set of pages that includes:</a></p>
 			          <p> </p></td>
 				      <td></td>
 				      <td></td>
@@ -960,11 +960,11 @@ aui-hidden="true"&gt;</pre>
 				      <th class="summary" scope="row">I need to understand the menu terms so I know where to find things.</th>
 				      <td class="summary"><strong>Understandable Language</strong>
 				        
-			          <p><strong>Support <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-personalization">personalization</a>.</strong></p></td>
+			          <p><strong>Support <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-personalization">personalization</a>.</strong></p></td>
 				      <td><p>The author can use simple and well understood terms.</p>
                         <p>OR </p>
                       <p>Authors need to make sure content adapts to user personalization settings to meet this need.</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+				      <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                         
                       <p></p></td>
 				      <td><p><strong>Editors' Note:</strong> add new text on known elements.</p>
@@ -978,13 +978,13 @@ aui-hidden="true"&gt;</pre>
 				        <p><strong>Headings</strong>, </p>
 				        <p resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x"><strong>Changes to</strong> <strong>3.2.4 - </strong><strong>Consistent Identification:</strong></p>
                         <p resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x"><strong>Changes to 3.2.3 Consistent Navigation</strong>: </p>
-				        <p><span property="xhv:role" resource="xhv:heading"> <strong>clear controls </strong></span></p>
+				        <p><strong>clear controls </strong></p>
 				        <p>See also</p>
-		                <h4 resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x" id="use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x"><span property="xhv:role" resource="xhv:heading">support  <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-personalization">personalization</a>.</span></h4>
+		                <h4 resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x" id="use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x">support <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-personalization">personalization</a>.</h4>
 		                <p resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x">..</p>
                       <p> </p></td>
 				      <td><h4 resource="#h-use-clear-visual-affordances.x" id="h-use-clear-visual-affordances.x">..</h4></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+				      <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                         
                       <p></p></td>
 				      <td><p>Position, text, and format on known elements are settable by users.</p>
@@ -1073,7 +1073,7 @@ Potential parts of a page
 				    <tr>
 				      <th scope="row">Multimedia - understandable structure. I find it easy to find the content needed. </th>
 				      <td><p> <strong>Manageable blocks of information</strong></p>
-			          <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong>(or the links can become a distraction). </p>
+			          <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong>(or the links can become a distraction). </p>
 			          <p><strong>Clear headings include multimedia.</p>
 			          
 			          </td>
@@ -1107,10 +1107,10 @@ Potential parts of a page
                           <li>Non-native content and sponsored content are clearly marked, and are visually differentiated by standardized techniques. </li>
                           <li> Clearly differentiate between facts and less-substantiated opinions. <strong>Editors' Note:</strong> was rewritten from "Clearly differentiate between opinions and facts. "</li>
                       </ol></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_simplification">Simplification</a></strong></span>
+				      <td><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_simplification">Simplification</a></strong>
 				        <p></p>
 				        
-				        <p><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a> </span>
+				        <p><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
 			            </p>
 				        
                       <p></p>
@@ -1125,7 +1125,7 @@ Potential parts of a page
 				      <th scope="row">I know what an advertisement is, or one from a different website. </th>
 				      <td><strong>consistent cues</strong>
                         <p>sufficient technique for third party content</p>
-                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">support personalization</a></strong></p><p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
+                      <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">support personalization</a></strong></p><p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        </td>
 				      <td>Non-native content and sponsored content are clearly marked, and are visually differentiated by standardized techniques. </td>
 				      <td><p><strong>Proposed attribute: </strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#distraction-explanation">aui-distraction</a></p>
@@ -1146,12 +1146,12 @@ Potential parts of a page
 			        </tr>
 				    <tr>
 				      <th scope="row">I know where to find things on a page. </th>
-				      <td><h4 resource="#h-a-predictable-design-is-used-within-a-set-of-pages-that-includes" id="h-a-predictable-design-is-used-within-a-set-of-pages-that-includes"><span property="xhv:role" resource="xhv:heading">Familiar layout:</span>                      </h4>
+				      <td><h4 resource="#h-a-predictable-design-is-used-within-a-set-of-pages-that-includes" id="h-a-predictable-design-is-used-within-a-set-of-pages-that-includes">Familiar layout: </h4>
 				        
                       <p>and </p>
                       
                       <p><strong>Changes to 3.2.2 - 3.2.4</strong></p></td>
-				      <td><p><strong>Editors' Note:</strong> techniques to include - making common components and   icons programmatically determinable enables their positions to be   standardized via <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-personalization">personalization</a>. </p>
+				      <td><p><strong>Editors' Note:</strong> techniques to include - making common components and icons programmatically determinable enables their positions to be   standardized via <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-personalization">personalization</a>. </p>
                         <div><p><strong>Editors' Note:</strong> techniques to include: example of COGA-WCAG technique.</p> In 2015, in websites with English text, a standard layout includes:
                           <ul>
                             <li>a search box in the upper0right corner;</li>
@@ -1160,7 +1160,7 @@ Potential parts of a page
                             <li>main menus at the tops of pages, under login and search, or on the left side.</li>
                           </ul>
                       </div></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span> </p>
+				      <td><p><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></p>
                         
                       <p></p></td>
 				      <td><p>Setting for positioning of elements (see above).</p>
@@ -1170,7 +1170,7 @@ Potential parts of a page
 			        </tr>
 				    <tr>
 				      <th scope="row">I know the design patterns. </th>
-				      <td><h4 resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following" id="h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following2"><span property="xhv:role" resource="xhv:heading">  clear controls </span></h4>
+				      <td><h4 resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following" id="h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following2">clear controls </h4>
 				        <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following">..</p>
 				        <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following"><strong>Familiar layout</strong></p>
 				        <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following">..</p>
@@ -1187,7 +1187,7 @@ Potential parts of a page
 				        <li>The qualities or properties of a control define its possible uses. It is clear how it can or should be used, and what action it will trigger.</li>
 				        <li>Actions and actionable items, which can be interacted with, should have a clear visual style that indicates how to interact with them (e.g., buttons that look like buttons). Visually clear controls can be made easily available though easy-to-use personalization (when available). </li>
 			          </ol></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
+				      <td><strong><a title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong>
                       <p></p></td>
 				      <td><p>Setting how roles and elements should be presented.</p>
 			          <p>Button view, CSS associated classes for each role or element type with pseudo states</p></td>
@@ -1195,18 +1195,18 @@ Potential parts of a page
 			        </tr>
 				    <tr>
 				      <th scope="row">Unambiguous affordances - I know what things are and what they do. </th>
-				      <td><h4 resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following" id="h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following4"><span property="xhv:role" resource="xhv:heading">clear controls </span></h4>
+				      <td><h4 resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following" id="h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following4">clear controls </h4>
                         <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following"><strong>Familiar layout</strong></p>
-                        <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following"><span property="xhv:role" resource="xhv:heading"><strong>Understandable language</strong> (instructions, labels, navigation, and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-important-information">important information</a> )</span></p>
+                        <p resource="#h-interactive-controls-are-visually-clear-or-visually-clear-controls-are-easily-available-that-conform-to-the-following"><strong>Understandable language</strong> (instructions, labels, navigation, and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-important-information">important information</a> )</p>
 			            <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">..</p>
                         <p><strong>Support personalization</strong></p>
                         <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">..</p>
 			            <p><strong>3.3.5 Help: (AA)</strong></p>
-                        <p>(Provided content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls.)</p>
+                        <p>(Provided content and information that help users understand <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls.)</p>
                         <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">..</p>
 		              </td>
 				      <td>aui-explain for more details on users interface</td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_language">Language type support</a></span>
+				      <td><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_language">Language type support</a>
 			          <p resource="#h-language-type-support">..</p>
 			          <p resource="#h-language-type-support">aui-explain for more details on users' interfaces</p></td>
 				      <td><p>as above</p>
@@ -1284,9 +1284,9 @@ Potential parts of a page
 				    <tr>
 				      <th scope="row"><p>I am familiar with the UI, and I know how to work it and what will happen when I work it. </p>
 				        <p> <a href="#Discussion7">more</a> </p></th>
-				      <td><p><strong><span property="xhv:role" resource="xhv:heading">Support personalization</span></strong><span property="xhv:role" resource="xhv:heading">.</span></p>
+				      <td><p><strong>Support personalization</strong>.</p>
 				        <p>Level A</p>
-					      <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
+					      <p><strong>Editors' Note:</strong> part of this could be addressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
 				        <p>--------</p>
 				        <h4 id="familiar2">Familiar layout: </h4>
@@ -1300,12 +1300,12 @@ Potential parts of a page
                         <p>aui-destination="home"</p>
                         <p>and additional landmarks or regions, such as </p>
                       <p>role=&quot;warning&quot;</p>
-					     <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
+					     <p><strong>Editors' Note:</strong> part of this could be addressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
                       
                       <p></p></td>
 				      <td class="summary"><p>User settings will need to address how to handle different contexts, such as aui-action="undo", for example, and which symbol to load for the setting. </p>
-                      <p>A mechanism is needed to read users' settings and adapt the page. Open source script is available/ being worked on at <a href="http://rawgit.com/ayelet-seeman/COGA.personalisation">http://rawgit.com/ayelet-seeman/COGA.personalisation</a></p>
+                      <p>A mechanism is needed to read users' settings and adapt the page. Open source script is available being worked on at <a href="https://github.com/ayelet-seeman/coga.personalisation">https://github.com/ayelet-seeman/coga.personalisation</a></p>
                       
                       <p>User settings for each contextual element include:</p>
                       <p>text;</p>
@@ -1365,7 +1365,7 @@ Potential parts of a page
 				        
 				        </td>
 				      <td>Techniques for using correct semantics, and importing a script that adapts a web page.</td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+				      <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                       <p></p>
                       
                       <p>And adding context nodes.</p></td>
@@ -1388,7 +1388,7 @@ Potential parts of a page
 				      <th scope="row">I need controls  to be consistently positioned on the screen.</th>
 				      <td>as the above</td>
 				      <td></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a> </span>
+				      <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                       <p></p></td>
 				      <td>Use of location as above with any element role, or context, or type.</td>
 				      <td></td>
@@ -1398,10 +1398,10 @@ Potential parts of a page
 				
 <p>Discussions</p>
 				<ul>
-					<li> User Preferences <a rel="nofollow" href="https://rawgit.com/w3c/COGA/master/issue-papers/preferences.html">https://rawgit.com/w3c/COGA/master/issue-papers/preferences.html</a></li>
-					<li> Adaptable Links and Buttons <a rel="nofollow" href="https://rawgit.com/w3c/COGA/master/issue-papers/links-buttons.html">https://rawgit.com/w3c/COGA/master/issue-papers/links-buttons.html</a></li>
-					<li> Symbols for Nonverbal <a rel="nofollow" href="https://rawgit.com/w3c/COGA/master/issue-papers/symbols-non-verbal.html">https://rawgit.com/w3c/COGA/master/issue-papers/symbols-non-verbal.html</a></li>
-					<li> Personalization <a rel="nofollow" href="https://rawgit.com/w3c/COGA/master/issue-papers/personalization.html">https://rawgit.com/w3c/COGA/master/issue-papers/personalization.html</a></li>
+					<li> User Preferences <a rel="nofollow" href="https://w3c.github.io/coga/issue-papers/preferences.html">https://w3c.github.io/coga/issue-papers/preferences.html</a></li>
+					<li> Adaptable Links and Buttons <a rel="nofollow" href="https://w3c.github.io/coga/issue-papers/links-buttons.html">https://w3c.github.io/coga/issue-papers/links-buttons.html</a></li>
+					<li> Symbols for Nonverbal <a rel="nofollow" href="https://w3c.github.io/coga/issue-papers/symbols-non-verbal.html">https://w3c.github.io/coga/issue-papers/symbols-non-verbal.html</a></li>
+					<li> Personalization <a rel="nofollow" href="https://w3c.github.io/coga/issue-papers/personalization.html">https://w3c.github.io/coga/issue-papers/personalization.html</a></li>
 					<li> Providing graded help <a rel="nofollow" href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Providing_graded_help">https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Providing_graded_help</a></li>
 					<li> Interoperable preference <a rel="nofollow" href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Interoperable_preference">https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Interoperable_preference</a></li>
 					<li> (<strong>Editors' Note:</strong> metadata support - to be added <a rel="nofollow" href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Meta_data_support">https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Meta_data_support</a>) </li>
@@ -1457,21 +1457,21 @@ Potential parts of a page
                     <th scope="row"><p>Understandable use of vocabulary, syntax, and other aspects of language.</p>
                       <p>Clear language</p>
                       <p> <a href="#Discussion7">more</a> </p></th>
-                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
+                    <td><p><strong><a href="https://w3c.github.io/coga/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
                       <p></p>
                       <p>Level A and AA </p>
                       <p>also </p>
-                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+                      <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong></p>
                       <p>--------</p>
                       <p><strong>To add</strong></p>
                       <p><strong>Provide clear language for all content.</strong></p>
                       <p>Level AAA</p>
                       
                       </td>
-                    <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">2.3 Writing style</a></span></p>
+                    <td><p><a href="https://w3c.github.io/coga/techniques/index.html#writing-style">2.3 Writing style</a></p>
                       <p>Use a clear writing style.</p>
                       <p></p>
-                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</span></p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</p>
                       <p></p></td>
                     <td>
                       <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#alternative-explanation">aui-alternative</a></strong></p>
@@ -1512,23 +1512,23 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>Clarify implied information and provide unambiguous information.</p>
                       <p> <a href="#Discussion7">more</a> </p></th>
-                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
+                    <td><p><strong><a href="https://w3c.github.io/coga/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
                       <p><span>Clear language in instructions</span> -  <strong>use literal text:</strong>(AA)</p>
                       <p>and </p>
-                      <p>Each step in instructions are identified and <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-concrete-wording">concrete wording</a> is used.</p>
+                      <p>Each step in instructions are identified and <a href="https://w3c.github.io/coga/extension/index.html#dfn-concrete-wording">concrete wording</a> is used.</p>
                       <p> </p>
                       <p>------------</p>
-                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+                      <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong></p>
                       <p></p>
                       
                       <p><strong>Editors' Note:</strong> add to AAA.</p>
                       <p>Clarify implied information and clarify the emotional content. </p></td>
-                    <td><p>Use a clear <a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">Writing style</a>.</p>
+                    <td><p>Use a clear <a href="https://w3c.github.io/coga/techniques/index.html#writing-style">Writing style</a>.</p>
                       <p></p>
-                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</span></p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</p>
                       <p></p>
                       <h4 resource="#h-be-clear-and-to-the-point" id="h-be-clear-and-to-the-point2">..</h4>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#give-instructions-clearly">2.3.2 Give instructions clearly</a></p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#give-instructions-clearly">2.3.2 Give instructions clearly</a></p>
                       <p></p></td>
                     <td><p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#literal-explanation">aui-literal</a></strong></p>
                       <p></p>
@@ -1549,20 +1549,20 @@ Potential parts of a page
                       <p>(representation of math by words instead of numbers)</p>
                       <p> <a href="#Discussion7">more</a> </p></th>
                     <td><p><strong>3.3.5 Help</strong></p>
-                      <p>Provide content and information that help users understand. <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
+                      <p>Provide content and information that help users understand. <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                       <p>Where an understanding of math is not a primary requirement for using content,  reinforce numbers with non-numerical values. </p>
                       <p>Simple search forms are excluded.</p>
                       
-                      <p><strong>Editors' Note:</strong> make sure there are sufficient techniques for <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a> and numbers.</p>
+                      <p><strong>Editors' Note:</strong> make sure there are sufficient techniques for <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a> and numbers.</p>
                       
                       <ul>
-                        <li> Charts or graphics are provided to aid comprehension of <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a> (COGA Techniques 2.7.3 ) </li>
+                        <li> Charts or graphics are provided to aid comprehension of <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a> (COGA Techniques 2.7.3 ) </li>
                         <li>Tables are provided to aid comprehension of information. </li>
                         <li>Understanding of math is not a primary requirement for using content. Reinforce numbers with   non-numerical values, e.g., Very Cold, Cold, Cool, Mild, Warm, Hot, Very Hot. </li>
                       </ul>
                       <p>------</p>
                       <p>Also see</p>
-                      <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong>
+                      <strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong>
                       
                       <h5 id="provided_content2">..</h5>
                       
@@ -1570,10 +1570,10 @@ Potential parts of a page
                     <td><p>Ability to have mathematical notation with text to speech to aid understanding.</p>
                       <p>Use of synchronized highlighting of complex graphics and formula with speech. </p>
                       <p>Associate maths, sections of math, and sections of complex items, with explanations.</p>
-                      <h5 resource="#h-relative-values" id="h-relative-values2"><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#relative-values">2.6.3.5 Relative values</a></span></h5>
+                      <h5 resource="#h-relative-values" id="h-relative-values2"><a href="https://w3c.github.io/coga/techniques/index.html#relative-values">2.6.3.5 Relative values</a></h5>
                       <p><strong>Editors' Note:</strong> this is not clear.</p>
                       <p></p>
-                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#relative-values">Use semantics to provide extra help</a>.</span></p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#relative-values">Use semantics to provide extra help</a>.</p>
                       <p></p>
                       
                       <p>Explain mathematical concepts with non-mathematical language. For example &quot;change 90% agree&quot;, to &quot;most users (90%) agree&quot;.</p></td>
@@ -1598,44 +1598,44 @@ Potential parts of a page
                     <th scope="row">Support for slow readers</th>
                     <td><p><strong>Manageable blocks of information:</strong></p>
                       <p><strong>Understandable language</strong></p>
-                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#Providea%20clearstructureandlayout">clear structure and relationships</a></strong>.</p>
+                      <p><strong><a href="https://w3c.github.io/coga/extension/index.html#Providea%20clearstructureandlayout">clear structure and relationships</a></strong>.</p>
                       <p></p>
-                      <p> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">When there is a barrier</strong>, between content and users, which requires additional cognitive function,  an alternative is provided that does not require additional cognitive function.</a></p>
+                      <p> <strong><a href="https://w3c.github.io/coga/extension/index.html#barrier">When there is a barrier</strong>, between content and users, which requires additional cognitive function,  an alternative is provided that does not require additional cognitive function.</a></p>
                       <p></p>
-                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+                      <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong></p>
                       <p></p>
                       <p><strong>clear text and voice</strong></p>
                       <p><strong>Critical features </strong>and important information are above the fold on most users' devices, and are accentuated in the preferred modalities of users, or they appear before other main content. </p>
                       <p><strong>Clear headings</strong></p>
                       <p><strong>Enable APIs</strong></p>
                       <p><strong>Help: (AA)</strong></p>
-                      <p>Provide content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
+                      <p>Provide content and information that help users understand <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                       <p>Where an understanding of math is not a primary requirement for using content, reinforce numbers with non-numerical values. </p>
                       <p><strong>Editors' Note: </strong> ensure sufficient techniques, as in the next volume.</p></td>
-                    <td><p>Use a clear <a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">writing style</a>.</p>
-                      <p>Use a<strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#Providea%20clearstructureandlayout"> clear structure</a></strong>.</p>
+                    <td><p>Use a clear <a href="https://w3c.github.io/coga/techniques/index.html#writing-style">writing style</a>.</p>
+                      <p>Use a<strong><a href="https://w3c.github.io/coga/extension/index.html#Providea%20clearstructureandlayout"> clear structure</a></strong>.</p>
                       <p></p>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-meaning">2.5 Help meaning</a></p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#help-meaning">2.5 Help meaning</a></p>
                       <p></p>
                       <p><strong>Editors' Note: </strong> ensure sufficient techniques.</p>
                       <p>For icons and jargon:</p>
                       <ul>
-                        <li>All icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> have short explanations available. Where a standard mechanism exists for the platform or technologies, it should be used (COGA Techniques 2.7.) (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> that clarify the meaning are provided.)</li>
+                        <li>All icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> have short explanations available. Where a standard mechanism exists for the platform or technologies, it should be used (COGA Techniques 2.7.) (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> that clarify the meaning are provided.)</li>
                       </ul>
                       <p>For content with more than 200 words, provide a summary. </p>
                       <ol>
                         <li>For pieces of content with fewer than 200 words, headings may act as summaries. </li>
-                        <li>The content owner identifies at least two <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-keywords-that-aid-comprehension">keywords that aid comprehension</a> for users. Keywords are programmatically determinable, and emphasized in the  preferred modalities of users. </li>
+                        <li>The content owner identifies at least two <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-keywords-that-aid-comprehension">keywords that aid comprehension</a> for users. Keywords are programmatically determinable, and emphasized in the  preferred modalities of users. </li>
                       </ol>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For key content and call out boxes</a>:</p>
+                      <p><a href="https://w3c.github.io/coga/extension/index.html#provided content">For key content and call out boxes</a>:</p>
                       <ul>
                         <li>Symbols are provided to help users identify key content including: types of contact information, main functions, warnings, and key points. Where a standard mechanism exists for the platform or technologies, it should be used. </li>
                       </ul>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For events</a>:</p>
+                      <p><a href="https://w3c.github.io/coga/extension/index.html#provided content">For events</a>:</p>
                       <ul>
                         <li>Enable users to set a reminder for   date and time sensitive events. Reminders should be set only at the   users request. Users should be able to personalize the reminder   method. Where a standard mechanism exists for the platform or technologies, it should be used</li>
                       </ul>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For forms and nonstandard controls</a></p>
+                      <p><a href="https://w3c.github.io/coga/extension/index.html#provided content">For forms and nonstandard controls</a></p>
                       <ol>
                         <li>Where a standard mechanism for the platform or technologies exist for context sensitive help, it should be   used. (Simple search forms are excluded.)</li>
                         <li>Instructions should be available for nonstandard controls. </li>
@@ -1693,7 +1693,7 @@ Potential parts of a page
                       <p>with sufficient techniques </p>
                       <p>For icons and jargon:</p>
                       <ul>
-                        <li>All icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> have short explanations available. Where a standard mechanism exists for the platform or technologies, it should be used. (COGA Techniques 2.7.)  (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> that clarify the meaning are provided..  )</li>
+                        <li>All icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> have short explanations available. Where a standard mechanism exists for the platform or technologies, it should be used. (COGA Techniques 2.7.)  (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://w3c.github.io/coga/extension/index.html#dfn-jargon">jargon</a> that clarify the meaning are provided..  )</li>
                       </ul>
                     <p>multimedia - See table 2 and 5 above. </p>
                     <p><strong>Editors' Note:</strong> ensure headings have multimedia sufficient techniques.</p>
@@ -1728,7 +1728,7 @@ Potential parts of a page
                          <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Proposal_for_WCAG ">Proposal for WCAG </a>
                            
               </p>
-                         <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html ">Techniques</a>
+                         <p><a href="https://w3c.github.io/coga/techniques/index.html ">Techniques</a>
                            
               </p>
 </section>
@@ -1764,7 +1764,7 @@ Potential parts of a page
                       <p> <a href="#Discussion8">more</a> </p>
                       
                     </th>
-                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">Accessible authentication</a></strong></p>
+                    <td><p><strong><a href="https://w3c.github.io/coga/extension/index.html#barrier">Accessible authentication</a></strong></p>
                     <p></p>
                     <p>and voice over IP criteria on barriers (<strong>Editors' Note:</strong> to be added)</p>
                     
@@ -1776,7 +1776,7 @@ Potential parts of a page
                     <h4 id="layout"><strong> Clear and understandable layout  </strong></h4>
                     <h4 id="familiar"><strong>A familiar design </strong></h4>
 <strong>Critical features </strong>
-                    <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>. </strong></p>
+                    <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>. </strong></p>
                     <h5 id="semantics2">..</h5>
                     
                     
@@ -1784,10 +1784,10 @@ Potential parts of a page
                     
                     </td>
                     <td> </td>
-                    <td><span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a></span>
+                    <td><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a>
                       <p></p>
                        
-                      <p><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+                      <p><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a>
                       </p>
                     <p></p></td>
                     <td>Settings for simplification and adding context as above.</td>
@@ -1798,10 +1798,10 @@ Potential parts of a page
                     <td>As above.
                       <p>and</p>
                     <p><strong>Help</strong></p>
-                    <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>:  </strong></p>
+                    <p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>:  </strong></p>
                     <p>Where the number of steps in a process can be reduced, users can control the tradeoff between function and simplification.</p></td>
                     <td><p><strong>Editors' Note:</strong> to be completed.</p></td>
-                    <td><span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a></span>
+                    <td><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a>
                     <p></p></td>
                     <td> Support for simplification as above, 
                                         <p><strong>Editors' Note:</strong> to be completed.</p></td>
@@ -1810,7 +1810,7 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>I need simple-to-navigate menu systems. </p>
                       </th>
-                    <td><span property="xhv:role" resource="xhv:heading"> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Clear language</a>:</strong></span>
+                    <td><strong><a href="https://w3c.github.io/coga/extension/index.html#instructions">Clear language</a>:</strong>
                       <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes"></p>
                       <p>See: In menus with sub menus: </p>
                       <ol>
@@ -1821,7 +1821,7 @@ Potential parts of a page
                         <li>each sub-menu item is clearly associated with a main menu item under which it falls. (This can be due to being an industry or a platform default.) </li>
                       </ol>
                       <p>) </p>
-                      <p><span property="xhv:role" resource="xhv:heading"><strong><a href="the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Help</a></strong></span></p>
+                      <p><strong><a href="the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Help</a></strong></p>
                       <p> </p>
                       <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes4">..</h4>
                       
@@ -1834,15 +1834,15 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>I need simple-to-navigate voice-menu systems.</p>
                       <p><a href="#Discussion8">more</a></p></th>
-                    <td><p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">1.4.4 When there is a barrier between content and users, which requires additional abilities, an alternative is provided that does not require additional abilities</a>.</p>
+                    <td><p><a href="https://w3c.github.io/coga/extension/index.html#barrier">1.4.4 When there is a barrier between content and users, which requires additional abilities, an alternative is provided that does not require additional abilities</a>.</p>
                       <p></p>
                     <p><strong>Editors' Note:</strong> add best practices?</p>
                     </td>
-                    <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">Human help</a></p>
+                    <td><p><a href="https://w3c.github.io/coga/techniques/index.html#Providehumanhelp">Human help</a></p>
                       <p></p>
                       <p><strong>Editors' Note:</strong> can we add a method to repeat a last option?</p>
                       
-                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Minimizethecognitiveskills">Minimize the cognitive skills required to use content when there is a known alternative</a>.</p>
+                      <p><a href="https://w3c.github.io/coga/techniques/index.html#Minimizethecognitiveskills">Minimize the cognitive skills required to use content when there is a known alternative</a>.</p>
                       <p></p>
                       
                       </td>
@@ -1867,12 +1867,12 @@ Potential parts of a page
 </section>
 	<section>
 <h4 id="Discussion8">Discussion</h4>
-            <p><a href="https://rawgit.com/w3c/COGA/master/issue-papers/voice-menus.html">Voice ML Issue Paper</a></p>
+            <p><a href="https://w3c.github.io/coga/issue-papers/voice-menus.html">Voice ML Issue Paper</a></p>
             <p><a href="https://lists.w3.org/Archives/Public/public-cognitive-a11y-tf/2016Mar/0001.html">EMMA examples</a> </p>
             <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Easy_Personalization">Script for personalization</a> and <a href="https://github.com/ayelet-seeman/COGA.personalisation">Example for personalization</a> </p>
               <p><a href="https://www.w3.org/TR/personalization-semantics-1.0/">Semantics</a></p>
               <p><a href="https://www.w3.org/WAI/PF/cognitive-a11y-tf/wiki/Proposal_for_WCAG ">Proposal for WCAG </a> </p>
-<p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html ">Techniques</a></p>
+<p><a href="https://w3c.github.io/coga/techniques/index.html ">Techniques</a></p>
 
 <h3 id="table9">Table 9: Navigation and GPS</h3>
 <p>About Users <strong>Editors' Note:</strong> to be completed.</p>
@@ -1902,7 +1902,7 @@ Potential parts of a page
     <tr>
       <th scope="row"><p>root option for simplicity - let me balance complexity and speed.</p>
       <p> <a href="#Discussion7">more</a> </p></th>
-      <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+      <td><p><strong><a href="https://w3c.github.io/coga/extension/index.html#semantics">Support personalization</a>.</strong></p>
         <p> </p>
         <p>Where the number of steps in a process can be reduced, enable users to control the trade off between function and simplification.</p>
         <p></p></td>
@@ -1916,7 +1916,7 @@ Potential parts of a page
     <tr>
       <th scope="row">Understandable terms, which make sense to users, and do not depend on knowing left and right, or on number dependence. </th>
       <td><p>3.3.5<strong> Help: (AA)</strong></p>
-        <p>Provide content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, relative and cardinal directions, forms, and nonstandard controls. </p>
+        <p>Provide content and information that help users understand <a href="https://w3c.github.io/coga/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, relative and cardinal directions, forms, and nonstandard controls. </p>
       <p>Where an understanding of math is not a primary requirement for using content, reinforce numbers with non-numerical values. </p>        </td>
       <td></td>
       <td><p><strong>Editors' Note:</strong> add for GPS.</p></td>

--- a/gap-analysis/table.html
+++ b/gap-analysis/table.html
@@ -61,14 +61,13 @@ table {border:thin; border-style:groove;}
         <p>--------</p>
         <p><strong>Editors' Note:</strong> does this support symbol users?</p>
         </td>
-      <td><p>Minimize cognitive skills required to use content - the examples in security.</p>
-        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#minimize-the-cognitive-skills-required-to-use-the-content-when-there-is-a-known-alternative">§ link</a>)</p>
+      <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Minimizethecognitiveskills"> Minimize the cognitive skills required to use the content</a> - the examples in security.</p>
         <p>Techniques should include how to have security that uses passwords or transcribing, such as biometrics and tokens.</p></td>
       <td>None</td>
       <td><p><strong>Editors' Note:</strong> we need to capture types of security these users can employ and, maybe, if they require the use of an API such as password storage.</td>
       <td>Hardware and operating systems could provide authentication to websites and applications. <p><strong>Editors' Note:</strong> needs further investigation and risk analysis.</p>
         
-        <p>Encourage a  standardized third party sign in, which is exclusively for authentication, and helps users login anywhere. </p></td>
+        <p>Encourage a standardized third party sign in, which is exclusively for authentication, and helps users login anywhere. </p></td>
       </tr>
     <tr>
       <th scope="row"> 
@@ -82,8 +81,7 @@ table {border:thin; border-style:groove;}
         <p>and</p>
         <p><strong>Do not automatically choose options that may disadvantage users</strong> without their approval, or add mechanisms likely to confuse users in a way that may do them harm.</p>
         <p>Level A</p>
-        <td><p>Keep users safe.</p>
-        <p>(<a  title="expand" class="expand" aria-label="expand" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#keep-the-user-safe">§ link</a>)</p>
+        <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#keep-the-user-safe"> Keep users safe</a>.</p>
         
         <p><strong>Editors' Note:</strong> add notify users when they are leaving a website if leaving it may cause them harm.</p>
         <p>Give positive and negative examples.</p></td>
@@ -132,14 +130,13 @@ table {border:thin; border-style:groove;}
 				        <p>--------</p>
 				        <p><strong>Editors' Note:</strong> this was accepted into WCAG 2.1 at level AAA.</p>
 			          </td>
-				      <td><p><span property="xhv:role" resource="xhv:heading">Attention and Focus</span></p>
-			          <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">§ link</a>)</p></td>
+				      <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">Attention and Focus</a></span></p>
+			          </td>
 				      <td>
-				        <p><strong>Proposed attribute: </strong> aui-distraction</p>
-				        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#distractions">§ link</a>)</p>
-				        <p><strong>Proposed attribute: </strong>aui-reminder</p>
-				        <p>Enable users to turn off less-helpful reminders.</p>
-			          <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#reminders">§ link</a>)</p></td>
+				        <p><strong>Proposed attribute: </strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#distraction-explanation">aui-distraction</a></p>
+				      
+				        <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/tools/index.html#use_case_reminder">aui-reminder</a></p>
+				        <p>Enable users to turn off less-helpful reminders.</p>			       
 				      <td><p><strong>Editors' Note:</strong> we need the formal user setting to enable  different responses to semantics.</p></td>
 				      <td></td>
 			        </tr>
@@ -186,7 +183,7 @@ table {border:thin; border-style:groove;}
 				      <td><p>As above.</p>
 			          <p>(See: A clear navigational path is provided for all content that: )</p></td>
 				      <td><p>As above</p>
-			            <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost" id="help-the-user-orient-themselves-and-regain-focus-when-it-is-lost2"><span property="xhv:role" resource="xhv:heading">Help users orient themselves and  regain focus when it is lost.</span></p>
+			            <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost" id="help-the-user-orient-themselves-and-regain-focus-when-it-is-lost2"><span property="xhv:role" resource="xhv:heading">Help users orient themselves and regain focus when it is lost.</span></p>
 		              </td>
 				      <td></td>
 				      <td></td>
@@ -202,7 +199,7 @@ table {border:thin; border-style:groove;}
 			              Unique <br />
 			              Media over five minutes long are divided into programmatically determinable and logical sections. Each section must be shorter than five minutes.<br />
 			              For multimedia,  chunks may include: steps in a process, slide changes, topic  changes.</p>
-<p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">..</p></td>
+						<p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">..</p></td>
 				      <td></td>
 				      <td></td>
 				      <td></td>
@@ -214,14 +211,14 @@ table {border:thin; border-style:groove;}
 			          <p>Enable users to set a reminder for date-and-time sensitive events. Reminders should be set only at users' request. Users should be able to personalize the reminder method. </p></td>
 				      <td><p>As above. And, if there is a calendar / mail program, it could provide a feature to notify users of an impending meeting or of tasks (broader scope). </p></td>
 				      <td><p><strong>Proposed attributes:</strong></p>
-				        <p>aui-message importance</p>
-                        <p>message from</p>
-                        <p>message context</p>
-                        <p>message time</p>
+				        <p><a href="https://w3c.github.io/personalization-semantics/tools/index.html#messageimportance-explanation">aui-messageimportance</a></p>
+                        <p><a href="https://w3c.github.io/personalization-semantics/tools/index.html#messagefrom-explanation">messagefrom</a></p>
+                        <p><a href="https://w3c.github.io/personalization-semantics/tools/index.html#messagecontext-explanation">messagecontext</a></p>
+                        <p><a href="https://w3c.github.io/personalization-semantics/tools/index.html#messagetime-explanation">messagetime</a></p>
                         <p>Enable users to turn off less-helpful reminders.</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#reminders">§ link</a>)</p></td>
+                      </td>
 				      <td><p>User settings for how reminders are handled, including preferred modalities of different levels. Examples are: email, SMS, call, pop up.</p>
-                      <p>Personalizing a reminder could include setting a type (e.g., personal, work, family).                    </p>
+                      <p>Personalizing a reminder could include setting a type (e.g., personal, work, family). </p>
                       <p> or </p>
                       <p>by user-defined groups of users and sites (most important to least important).</p>
 					  <p> or </p>
@@ -230,7 +227,7 @@ table {border:thin; border-style:groove;}
 				      <td></td>
 			        </tr>
 				    <tr>
-				      <th scope="row"><p>I need to turn off distractions 1) to       be a default, and 2) to be a trivial option in real       time.</p>
+				      <th scope="row"><p>I need to turn off distractions 1) to be a default, and 2) to be a trivial option in real time.</p>
 			          <p>(Assume I have an attention disability, and/or an impaired short-term memory, and/or impaired executive function).</p></th>
 				      <td><p>As above</p>
 			          <p>and </p>
@@ -240,8 +237,8 @@ table {border:thin; border-style:groove;}
 			          
 			          <p><strong>Support  personalization.</strong></p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading">Enable users to determine levels of interruptions as easily as possible.</span>
-			            <p resource="#alow-the-user-to-determine-levels-of-interruptions-as-easily-as-possible.x">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#alow-the-user-to-determine-levels-of-interruptions-as-easily-as-possible.xProvide_mechanisms_that_help_the_user_focus_and_restore_context_if_attention_is_lost">§ link</a>)</p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#alow-the-user-to-determine-levels-of-interruptions-as-easily-as-possible">Enable users to determine levels of interruptions as easily as possible.</a></span>
+				      	<p></p></td>
 				      <td><p>As above.</p>
                       <p></p></td>
 				      <td><p>User settings for distractions need to be interoperable.</p>
@@ -266,8 +263,8 @@ table {border:thin; border-style:groove;}
                         <li>non-critical messages that can easily be turned off and on again.</li>
                       </ul>
                       </td>
-				      <td><p>Operating System Tool</p>
-			          <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/issue-papers/distractions.html#">§ link</a>) </p>
+				      <td><p><a href="https://rawgit.com/w3c/COGA/master/issue-papers/distractions.html">Operating System Tool</a></p>
+			          <p></p>
 			          <p>See Integrated solution.</p>
 			          <p> It is based on a matrix for distractions at the operating system,   browser, or cloud level. Users can turn off  distractions, such   as Skype  and Facebook, across different devices, and then may forget   to turn them back on. This idea manages all distractions by forming a   cross-application and cross-device distraction matrix that manages all   distractions in one setting.</p></td>
 			        </tr>
@@ -344,30 +341,30 @@ table {border:thin; border-style:groove;}
 				        <p>AA - provide  beginner help, and easy access to human help, on forms and interactive controls for critical services.</p>
 				        
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading">Prevent Errors</span>
-			          <p resource="#prevent-errors">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">Prevent Errors</a></span>
 			          <p resource="#prevent-errors">..</p>
-<span property="xhv:role" resource="xhv:heading">Provide Help</span>
-			          <p resource="#provide-help">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">§ link</a>)</p>
+<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">Provide Help</a></span>
+			          
 			          <p resource="#provide-help">..</p>
 			          <p resource="#prevent-errors"> COGA Techniques 2.7:  aui-explain to explain any nonstandard UI where they cannot be.</p></td>
 				      <td> <strong>Explain and feedback</strong>
-<p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-explain-and-feedback" >§ link</a>)</p>
-<span property="xhv:role" resource="xhv:heading"><strong>Adding Context </strong></span>
+				      	<p></p>
+
+<span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
 		              <p>Standardize supportive syntax and terms that can be linked, for users, to associated   symbols, terms, translations, and explanations.</p>
-		              <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
+		              <p></p>
 		              
-		              <p><strong>Log </strong></p>
+		              <p><strong><a href="https://w3c.github.io/personalization-semantics/tools/index.html#all-log-explanation">Log</a> </strong></p>
 		              <p>This proposal is to track tasks users have done so they can be reminded of them; and return to or fix  a task. </p>
-		              <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#logs">§ link</a>)</p>
+		              <p></p>
 		              
 		              <p><strong>Help</strong></p>
-		              <p>Some users may need additional   information, or specifically additional-help information. We request   additonal attributes so an author can indicate existence of   additional information.</p>
-                      <p><strong>Proposed attribute: </strong>aui-moreinfo</p>
+		              <p>Some users may need additional information, or specifically additional-help information. We request additonal attributes so an author can indicate existence of additional information.</p>
+                      <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#moreinfo-explanation">aui-moreinfo</a></p>
                       <p><strong>Supported values: </strong>URI</p>
-                      <p><strong>Proposed attribute: </strong>aui-extrahelp</p>
+                      <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#extrahelp-explanation">aui-extrahelp</a></p>
                       <p><strong>Supported values: </strong>URI</p>
-                      <p><strong>Proposed attribute: </strong>aui-helptype</p></td>
+                      <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#helptype-explanation">aui-helptype</a></p></td>
 				      <td><p>Settings for how help is handled</p>
 				        <p><strong>aui-Log</strong></p>
 				        <p>Keep login (binary)</p>
@@ -389,7 +386,7 @@ Never<br />
 Always    open</p>
 			          <p>location</p>
 			          
-			          <p><strong>Help    panel content</strong></p>
+			          <p><strong>Help panel content</strong></p>
 			          <p> tooltips / human help / more help / topics earch</p>
 			          <p>/automated / FAQs / help form / simplified / glossary/</p>
 			          <p>dictionary / thesaurus</p>
@@ -419,17 +416,17 @@ Always    open</p>
 			        </tr>
 				    <tr>
 				      <th scope="row">I need to know what mistake I made and how to correct a mistake. It does not cause undue alarm when I make a mistake and can correct it easily. </th>
-				      <td><strong>Provide Feedback</strong>
-			            <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#The_success_or_failure_of_every_action_should_be_clearly_indicated_to_the_user_and_visual_rapid_feedback_should_be_available._Spoken_feedback_should_be_a_user_selectable_option.">§ link</a>)</p>
-			          <p><strong>Undo</strong></p>
+				      <td><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option"> Provide Feedback</a></strong>
+			            <p></p>
+			          <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#support">Undo</a></strong></p>
 			          <p>A simple mechanism is provided to enable users to undo mistakes. Users can repair information via clearly-labeled actions. Users can get back to   the place they were at in one clearly-labeled action with unwanted loss   of data. </p>
-			          <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Support_is_provided_that_help_users_complete_and_check_their_task.2C_that_includes">§ link</a>)</p>
+			          <p></p>
 			          <p><strong>Editors' Note:</strong> also covered in WCAG in 3.3.1.</p>
 			          <p><strong>Editors' Note:</strong> making error-message text understandable is covered in WCAG in
                       <strong>Understandable language</strong>.</p>
-                      <p><span><em>Instructions, labels, navigation ..</em></span>
+                      <p><span><em><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Instructions, labels, navigation ..</a></em></span>
                       </p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Instructions.2C_labels.2C_navigation_and_important_information_are_provided_with_a_clear_writing_style_that_includes:">§ link</a>)</p>
+                      <p></p>
 			          <p><strong>Editors' Note:</strong> also see WCAG 3.3.4 Error Prevention (Legal, Financial, Data) (financial legal and user data) and 3.3.6 (All).</p>
 			          <p><strong>Editors' Note:</strong> change to 3.3.4 Error Prevention.</p>
 			          <p><strong>Editors' Note:</strong> WCAG 3.3.4 to include important information (such as health).</p>
@@ -438,18 +435,18 @@ Always    open</p>
 			          
 			          
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading">Make it easy to undo mistakes.</span>
-			          <p resource="#make-it-easy-to-undo-mistakes">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">§ link</a>)</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading">9. Explain and feedback</span>
-                        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-explain-and-feedback2">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes.</a></span>
+			          <p resource="#make-it-easy-to-undo-mistakes"></p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#explain-explanation">Explain</a> and <a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">Feedback</a></span>
+                        <p></p>
                         
                         <p><strong>Editors' Note:</strong> change feedback to a role.</p>
                         
-                        <p><strong>aui-moreinfo</strong></p>
+                        <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#moreinfo-explanation">aui-moreinfo</a></strong></p>
                         <p>This supports a URI where more help is provided (often with an aui-extrahelp support).</p>
                         
                         
-                        <p><strong>aui-extrahelp</strong> </p>
+                        <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#extrahelp-explanation">aui-extrahelp</a></strong> </p>
                         
                         <p>This is really an element with a help role.</p>
                         <p>The attribute defines which type of help it is:  tooltips / human help / more help.</p>
@@ -459,7 +456,7 @@ Always    open</p>
                                               </td>
 				      <td><p>See <em>Settings for how Explain and feedback</em> above.</p>
 			          
-			          <p>Should <strong>aui-moreinfo</strong> links be shown:</p>
+			          <p>Should <strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#moreinfo-explanation">aui-moreinfo</a></strong> links be shown:</p>
 			          <ul>
 			            <li>never;</li>
 			            <li>text;</li>
@@ -467,7 +464,7 @@ Always    open</p>
 			            <li>icon and text?</li>
 			            </ul>
 			          
-			          <p><strong>aui-helptype</strong> - for each type </p>
+			          <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#helptype-explanation">aui-helptype</a></strong> - for each type </p>
 			          <p>tooltips / human help/ more help</p>
                       <p>/ glossary / dictionary / thesaurus, etc.:</p>
                       
@@ -485,20 +482,20 @@ Always    open</p>
 			        </tr>
 				    <tr>
 				      <th scope="row">I need enough time, and  not lose my work. </th>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong>Changes to timed events</strong>.</span>
-		                <p >(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#h-timed-event-are-not-used-except-for-the-situations-listed-below.x">§ link</a>)</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Help users complete and check their work.</span>				        
-				        <p resource="#provide-help">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-users-complete-and-check-their-work">§ link</a>)</p>
-<span property="xhv:role" resource="xhv:heading">Enough Time</span>
-                      <p resource="#enough-time">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#enough-time">§ link</a>)</p>
-<span property="xhv:role" resource="xhv:heading">Avoid Loss of data. </span>
-                      <p resource="#avoid-loss-of-data">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#avoid-loss-of-data">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#timed">Changes to timed events</a></strong>.</span>
+		                <p ></p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-users-complete-and-check-their-work">Help users complete and check their work</a>.</span>				        
+				        <p resource="#provide-help"></p>
+<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#enough-time">Enough Time</a></span>
+                      <p resource="#enough-time"></p>
+<span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#avoid-loss-of-data">Avoid Loss of data</a>.</span>
+                      <p resource="#avoid-loss-of-data"></p>
                       </td>
 				      <td></td>
 				      <td><p>Users can set that the data are / are not stored.</p>
 				        <p>Users can set a time minimum for  controlling how long they  see timeout messages.</p>
 			          </td>
-				      <td>><strong>Editors' Note:</strong> issue paper may be needed to explore how to enable automatic acceptance of cookies, and stored data, to avoid data loss  for certified or safe sites; and for limited usage or time.</td>
+				      <td><p><strong>Editors' Note:</strong> issue paper may be needed to explore how to enable automatic acceptance of cookies, and stored data, to avoid data loss  for certified or safe sites; and for limited usage or time.</p></td>
 			        </tr>
 				    <tr>
 				      <th scope="row"><p>I want to use applications or APIs that help me, such as remembering my information so I do not need to enter it again, and to help me (such as spelling).</p></th>
@@ -524,8 +521,8 @@ Always    open</p>
 				        <p>See also:</p>
                       <p><span property="xhv:role" resource="xhv:heading"> <strong>Clear structure </strong></span> and relationships</p>
                       <p><strong>Help</strong>:</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Help users  orient themselves, and  regain focus when it is lost.</span>
-				        <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-the-user-orientate-themselves-and-regain-focus-when-it-is-lost">Help users orient themselves, and regain focus when it is lost</a>.</span>
+				        <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost"></p>
 			          <p resource="#help-the-user-orient-themselves-and-regain-focus-when-it-is-lost">..</p></td>
 				      <td><p>LOG</p>
 			          <p><strong>Editors' Note:</strong> add how to identify steps in a process, and current position, so users can have breadcrumbs or other mechanisms of their choice.</p>
@@ -555,8 +552,8 @@ Always    open</p>
 			          <p><strong>Help</strong></p>
 			          <p>Change to timed events. </p>
 			          <p>The timeframe for reversing transactions is machine  readable.</p></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading">Make it easy to undo mistakes.</span></p>
-                        <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">§ link</a>)</p>
+				      <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#make-it-easy-to-undo-mistakes">Make it easy to undo mistakes</a>.</span></p>
+                        <p></p>
                       <p></p></td>
 				      <td><p>Log</p>
 			          
@@ -647,11 +644,9 @@ Always    open</p>
 				        <p>Level A</p>
 				        
 			          </td>
-				      <td><p resource="#provide-help"> COGA Techniques 2.7:  <span property="xhv:role" resource="xhv:heading">Prevent errors.</span> </p>
-			          <p resource="#prevent-errors">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">§ link</a>)</p>
+				      <td><p resource="#provide-help"> COGA Techniques 2.7:  <span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#prevent-errors">Prevent Errors</a>.</span> </p>
                       <p resource="#prevent-errors">..</p>
-                      <span property="xhv:role" resource="xhv:heading">Provide Help</span>
-                      <p resource="#provide-help">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">§ link</a>)</p>
+                      <span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-help">Provide Help</a>.</span>
                       <p resource="#provide-help">..</p>
                       <p resource="#prevent-errors"> COGA Techniques 2.7 </p>
                       <p>For icons and jargon:</p>
@@ -670,21 +665,21 @@ Always    open</p>
                       <p resource="#prevent-errors">..</p>
                       <p resource="#prevent-errors"><strong>Editors' Note:</strong> check that the way  sufficient techniques are done really meet the use cases.</p></td>
 				      <td>
-				        <span property="xhv:role" resource="xhv:heading"><strong>Adding Context </strong></span>
+				        <span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
 				        <p>Standardize supportive syntax and terms that can be linked to associated   symbols, terms, translations, and explanations for users. </p>
-				        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
-				        <p><span property="xhv:role" resource="xhv:heading"><strong>More Help</strong></span></p>
-			          <p resource="#h-more-help">(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-more-help">§ link</a>)</p></td>
+				        <p></p>
+				        <p><span property="xhv:role" resource="xhv:heading"><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></strong></span></p>
+			          <p resource="#h-more-help"></p></td>
 				      <td>See help personalization in table above.</td>
 				      <td></td>
 			        </tr>
 				    <tr>
 				      <th scope="row"><p>I know how to get more information.</p>
 			          <p> <a href="#Discussion7">more</a> </p></th>
-				      <td><p><strong>support    personalization.</strong></p>
+				      <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support Personalization</a>.</strong></p>
 					     <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
-                        <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/extension/index.html#Use_semantics_and_safe_standardized_techniques_that_enable_the_content_to_be_adapted_to_the_user_scenario_including_enabling_additional_support_and_personalization.">§ link</a>)</p>
+                        <p></p>
                         <h5 id="semantics3">..</h5>
 				        <p><strong>Critical features</strong> and important information are above the   fold on users' devices, and are accentuated in the preferred modality of a   user, or they appear before other main content. </p>
                         
@@ -695,8 +690,8 @@ Always    open</p>
 				        
 				        
 				        
-				        <p><span property="xhv:role" resource="xhv:heading"> Support is provided that helps users understand content, which includes:</span> </p>
-				        <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes2"><span property="xhv:role" resource="xhv:heading"><span typeof="bookmark"><a property="url" title="Permalink for 3.6.2 Support is provided that help users understand the content, that includes:" aria-label="Permalink for 3.6.2 Support is provided that help users understand the content, that includes:" href="https://rawgit.com/w3c/COGA/master/extension/index.html#support-is-provided-that-help-users-understand-the-content-that-includes"><span content="3.6.2 Support is provided that help users understand the content, that includes:" property="title">§ link</span></a></span></span></h4>
+				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Support is provided that helps users understand the content</a>, which includes:</span> </p>
+				        <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes2"><span property="xhv:role" resource="xhv:heading"><span typeof="bookmark"></span></span></h4>
 				        <p>Level A</p>
 				        <p>--------</p>
 				        <p>a familiar interface to identify help and contact us;</p>
@@ -704,20 +699,19 @@ Always    open</p>
 				        <p>---</p>
 				        <p><strong>Editors' Note:</strong> add at AAA. Provide links to more information.</p></td>
 				      <td><p resource="#prevent-errors">..</p></td>
-				      <td> Explanation and Feedback
-				        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-explain-and-feedback" >§ link</a>)</p>
-				        <span property="xhv:role" resource="xhv:heading">Adding Context </span>
+				      <td> <a href="https://w3c.github.io/personalization-semantics/help/index.html#explain-explanation">Explain</a> and <a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">Feedback</a>
+				        <p></p>
+				        <span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
 				        <p>For users, standardize supportive syntax and terms that can be linked to associated   symbols, terms, translations, and explanations</p>
-				        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
-				        <p><span property="xhv:role" resource="xhv:heading">More Help</span> </p>
-				        <p resource="#h-more-help">(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-more-help">§ link</a>)</p>
+				        <p></p>
+				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></span> </p>
 				        <p resource="#h-more-help">..</p>
 				        <p><strong>Requirement: </strong>Some users may need additional   information, or specifically additional help information. There should be  extra attributes so an author can indicate the existence of additional information.</p>
-                        <p><strong>Proposed attribute: </strong>aui-moreinfo</p>
+                        <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#moreinfo-explanation">aui-moreinfo</a></p>
                         <p><strong>Supported values: </strong>URI</p>
-                        <p><strong>Proposed attribute: </strong>aui-extrahelp</p>
+                        <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#extrahelp-explanation">aui-extrahelp</a></p>
                         <p><strong>Supported values: </strong>URI</p>
-					      <p><strong>Proposed attribute: </strong>aui-helptype</p>
+					      <p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#helptype-explanation">aui-helptype</a></p>
                         <p><strong>Supported values: </strong> tooltips / human help / more help / topic search / automated / faqs / help form / simplified / glossary / dictionary / thesaurus</p>
                         <p> </p>
                         <p><strong>Example:</strong></p>
@@ -750,12 +744,12 @@ aui-hidden="true"&gt;</pre>
 	                    
 	                  <p>AAA human help is provided</p>
                       </td>
-				      <td><span property="xhv:role" resource="xhv:heading">Provide human help</span>
-			          <p resource="#Providehumanhelp">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">§ link</a>)</p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">Provide Human Help</a></span>
+			          <p resource="#Providehumanhelp"></p></span></td>
 				      <td><p resource="#h-more-help">..</p>
-				        <p><span property="xhv:role" resource="xhv:heading">More Help</span></p>
+				        <p><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_morehelp">More Help</a></span></p>
 				        <p>(see above)</p>
-                      <p resource="#h-more-help">(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-more-help">§ link</a>)</p></td>
+                      <p resource="#h-more-help"></td>
 				      <td></td>
 				      <td></td>
 			        </tr>
@@ -763,8 +757,8 @@ aui-hidden="true"&gt;</pre>
 				      <th scope="row">I need symbols that help me understand content. </th>
 				      <td><p><strong>Provide content and information that help users understand content.</strong></p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading">2.5.3 Use symbols and images to show meaning.</span>
-				        <p resource="#h-use-symbols-and-images-to-show-meaning">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#h-use-symbols-and-images-to-show-meaning">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.</span>
+				        <p resource="#h-use-symbols-and-images-to-show-meaning"></p>
 				        
 				        
 				        <p><strong>Editors' Note:</strong> add technique to enable interoperable symbol mapping for products for nonverbal users. Part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
@@ -775,9 +769,9 @@ aui-hidden="true"&gt;</pre>
 			            </li>
 			          </ul></td>
 				      <td><p resource="#h-more-help">..</p>
-			          <p resource="#h-more-help"><span property="xhv:role" resource="xhv:heading">Adding Context </span> </p>
+			          <p resource="#h-more-help"><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span> </p>
 			          
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td></td>
 				      <td></td>
 			        </tr>
@@ -797,13 +791,12 @@ aui-hidden="true"&gt;</pre>
                           <li> Charts or graphics are provided where they aid comprehension of <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a> (COGA Techniques 2.7.3.) </li>
                         </ul>
                       				        <p resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes">..</p></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading">2.5 Help meaning</span></p>
-				        <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#h-help-meaning">§ link</a>)
-			            </p>
-<span property="xhv:role" resource="xhv:heading">2.5.3 Use symbols and images to show meaning.</span>
-			          <p resource="#h-use-symbols-and-images-to-show-meaning">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#h-use-symbols-and-images-to-show-meaning">§ link</a>)</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Adding Context </span>
-                        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
+				      <td><p><span property="xhv:role" resource="xhv:heading"><a title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-meaning">Help meaning</a></span></p>
+				        <p></p>
+<span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-symbols-and-images-to-show-meaning">Use symbols and images to show meaning</a>.</span>
+			          <p resource="#h-use-symbols-and-images-to-show-meaning"></p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+                        <p></p>
                       
                       </td>
 				      <td></td>
@@ -812,8 +805,8 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row">I need speech support, with synchronized highlighting, so I can follow as I go. </th>
 				      <td><strong>Support known <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-standardized-APIs">standardized APIs</a> for tools that help users understand and use  content. </strong> This includes:</td>
-				      <td><span property="xhv:role" resource="xhv:heading">Provide speech support</span>
-                      <p resource="#provide-speech-support">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-speech-support">§ link</a>)</p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#provide-speech-support">Provide Speech Support</a></span>
+                      <p resource="#provide-speech-support"></p></td>
 				      <td><p><strong>Editors' Note:</strong> do we need semantics that identify phrases?</p>
 				        
 			          <p>Use ARIA described to correlate pictures and focus rings (sections of pictures); and sections of math with text; or <strong>Editors' Note:</strong> do we need a new semantic?</p></td>
@@ -831,12 +824,12 @@ aui-hidden="true"&gt;</pre>
 			        </tr>
 				    <tr>
 				      <th scope="row">  I need rapid feedback. </th>
-				      <td><p id="API"><strong>Provide feedback.</strong></p>
+				      <td><p id="API"><strong>Provide Feedback.</strong></p>
 				        
 			                                  <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes3">..</h4></td>
 				      <td><p resource="#provide-speech-support">..</p></td>
-				      <td>COGA -feedback
-                        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-explain-and-feedback" >§ link</a>)</p>
+				      <td><a href="https://w3c.github.io/personalization-semantics/help/index.html#feedback-explanation">aui-feedback</a>
+                        <p></p>
                       </td>
 				      <td><p>Feedback is spoken: on / off</p>
 			          </td>
@@ -886,11 +879,11 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row">I do not want too many reminders, as I will be distracted.</th>
 				      <td><strong>Reminders: </strong>Reminders should be set only at users' requests. Users should be   able to personalize the reminder method. Where a standard mechanism   exists for the platform or technologies, it should be used.</td>
-				      <td><span property="xhv:role" resource="xhv:heading">Attention and Focus</span>
-			          <p resource="#attention-and-focus">(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">§ link</a>)</p></td>
-				      <td><p><strong>Proposed attribute: </strong>aui-reminder</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#attention-and-focus">Attention and Focus</a></span>
+			          <p resource="#attention-and-focus"></p></td>
+				      <td><p><strong>Proposed attribute: </strong><a href="https://w3c.github.io/personalization-semantics/tools/index.html#use_case_reminder">aui-reminder</a></p>
                         <p>Enable users to turn off less-helpful reminders.</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#reminders">§ link</a>)</p>
+                      <p></p>
                       
                       <p>See table 2.</p></td>
 				      <td><p>See table 2.<br />
@@ -937,17 +930,17 @@ aui-hidden="true"&gt;</pre>
 				    <tr>
 				      <th scope="row"><p>Controls are clear.  </p>
 				        <p> <a href="#Discussion7">more</a> </p></th>
-				      <td> <strong>clear controls </strong>
-<p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Interactive_controls_are_visually_clear_or_visually_clear_controls_are_easily_available_that_conform_to_the_following:">§ link</a>)</p>
+				      <td> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#controls">clear controls</a></strong>
+<p></p>
 				        <p>Level A</p>
 				        <p>--------</p>
 				        <p><strong>Editors' Note:</strong> to add</p>
 			          </td>
-				      <td><span property="xhv:role" resource="xhv:heading">2.6.1 Use clear visual affordances.</span>
-			          <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#">§ link</a>)</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong>Adding Context </strong></span>
+				      <td><span property="xhv:role" resource="xhv:heading"><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#use-clear-visual-affordances">Use clear visual affordances</a>.</span>
+			          <p></p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
                         
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td><p>Identify how to present different roles, elements, and context elements.</p>
 			          <p>See table 6.</p>
 			          
@@ -956,8 +949,8 @@ aui-hidden="true"&gt;</pre>
 			        </tr>
 				    <tr>
 				      <th scope="row"></th>
-				      <td><p>A predictable design is used within a set of pages that includes:</p>
-			          <p> (<a title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#">A_predictable_design_is_used_within_a_set_of_pages_that_includes:">§ link</a>)</p></td>
+				      <td><p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#324">A predictable design is used within a set of pages that includes:</a></p>
+			          <p> </p></td>
 				      <td></td>
 				      <td></td>
 				      <td></td>
@@ -971,9 +964,9 @@ aui-hidden="true"&gt;</pre>
 				      <td><p>The author can use simple and well understood terms.</p>
                         <p>OR </p>
                       <p>Authors need to make sure content adapts to user personalization settings to meet this need.</p></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Adding Context </span>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
                         
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td><p><strong>Editors' Note:</strong> add new text on known elements.</p>
 			          <p>See table 6 row 1</p></td>
 				      <td></td>
@@ -991,9 +984,9 @@ aui-hidden="true"&gt;</pre>
 		                <p resource="#use-semantics-and-safe-standardized-techniques-that-enable-the-content-to-be-adapted-to-the-user-scenario-including-enabling-additional-support-and-personalization.x">..</p>
                       <p> </p></td>
 				      <td><h4 resource="#h-use-clear-visual-affordances.x" id="h-use-clear-visual-affordances.x">..</h4></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Adding Context </span>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
                         
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td><p>Position, text, and format on known elements are settable by users.</p>
 				        
 				        <p>Hiding of less important content</p>
@@ -1080,7 +1073,7 @@ Potential parts of a page
 				    <tr>
 				      <th scope="row">Multimedia - understandable structure. I find it easy to find the content needed. </th>
 				      <td><p> <strong>Manageable blocks of information</strong></p>
-			          <p><strong>Support personalization. </strong>(or the links can become a distraction). </p>
+			          <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong>(or the links can become a distraction). </p>
 			          <p><strong>Clear headings include multimedia.</p>
 			          
 			          </td>
@@ -1114,13 +1107,13 @@ Potential parts of a page
                           <li>Non-native content and sponsored content are clearly marked, and are visually differentiated by standardized techniques. </li>
                           <li> Clearly differentiate between facts and less-substantiated opinions. <strong>Editors' Note:</strong> was rewritten from "Clearly differentiate between opinions and facts. "</li>
                       </ol></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Simplification</span>
-				        <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-simplification">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_simplification">Simplification</a></strong></span>
+				        <p></p>
 				        
-				        <p><span property="xhv:role" resource="xhv:heading">Adding Context </span>
+				        <p><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a> </span>
 			            </p>
 				        
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
+                      <p></p>
                       
 Potential parts of a page
                       
@@ -1132,11 +1125,11 @@ Potential parts of a page
 				      <th scope="row">I know what an advertisement is, or one from a different website. </th>
 				      <td><strong>consistent cues</strong>
                         <p>sufficient technique for third party content</p>
-                      <p><strong>support personalization</strong></p><p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
+                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">support personalization</a></strong></p><p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        </td>
 				      <td>Non-native content and sponsored content are clearly marked, and are visually differentiated by standardized techniques. </td>
-				      <td><p><strong>Proposed attribute: </strong> aui-distraction</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#distractions">§ link</a>)</p>
+				      <td><p><strong>Proposed attribute: </strong><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#distraction-explanation">aui-distraction</a></p>
+                      <p></p>
                       <p><strong>Potential parts of a page</strong></p>
                       <p><strong>Examples:</strong></p>
                       <ul>
@@ -1167,9 +1160,9 @@ Potential parts of a page
                             <li>main menus at the tops of pages, under login and search, or on the left side.</li>
                           </ul>
                       </div></td>
-				      <td><p><span property="xhv:role" resource="xhv:heading"><strong>Adding Context</strong></span> </p>
+				      <td><p><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span> </p>
                         
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td><p>Setting for positioning of elements (see above).</p>
 			          
 			          <p>Enabling users to set a familiar layout, such as Android, Windows, iOS, and which version (or this should set individual settings as a template).</p></td>
@@ -1194,8 +1187,8 @@ Potential parts of a page
 				        <li>The qualities or properties of a control define its possible uses. It is clear how it can or should be used, and what action it will trigger.</li>
 				        <li>Actions and actionable items, which can be interacted with, should have a clear visual style that indicates how to interact with them (e.g., buttons that look like buttons). Visually clear controls can be made easily available though easy-to-use personalization (when available). </li>
 			          </ol></td>
-				      <td><span property="xhv:role" resource="xhv:heading"><strong>Adding Context </strong></span>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong></span>
+                      <p></p></td>
 				      <td><p>Setting how roles and elements should be presented.</p>
 			          <p>Button view, CSS associated classes for each role or element type with pseudo states</p></td>
 				      <td></td>
@@ -1213,8 +1206,7 @@ Potential parts of a page
                         <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">..</p>
 		              </td>
 				      <td>aui-explain for more details on users interface</td>
-				      <td><span property="xhv:role" resource="xhv:heading">Language type support</span>
-			          <p resource="#h-language-type-support">(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-language-type-support">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a href="https://w3c.github.io/personalization-semantics/help/index.html#use_case_language">Language type support</a></span>
 			          <p resource="#h-language-type-support">..</p>
 			          <p resource="#h-language-type-support">aui-explain for more details on users' interfaces</p></td>
 				      <td><p>as above</p>
@@ -1292,7 +1284,7 @@ Potential parts of a page
 				    <tr>
 				      <th scope="row"><p>I am familiar with the UI, and I know how to work it and what will happen when I work it. </p>
 				        <p> <a href="#Discussion7">more</a> </p></th>
-				      <td><p><strong>S<span property="xhv:role" resource="xhv:heading">upport  personalization</span></strong><span property="xhv:role" resource="xhv:heading">.</span></p>
+				      <td><p><strong><span property="xhv:role" resource="xhv:heading">Support personalization</span></strong><span property="xhv:role" resource="xhv:heading">.</span></p>
 				        <p>Level A</p>
 					      <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
@@ -1301,7 +1293,7 @@ Potential parts of a page
 				        
 			          </td>
 				      <td class="summary"></td>
-				      <td class="summary"><p>Adding Context</p>
+				      <td class="summary"><p><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></p>
 				        <p>In adding a semantic for the context (what the thing is for), such as:</p>
                         <p>aui-action="undo" </p>
                         <p>or </p>
@@ -1311,7 +1303,7 @@ Potential parts of a page
 					     <p><strong>Editors' Note:</strong> part of this could be adressed in WCAG 2.1 at level AAA by 1.3.5.</p>
 				        
                       
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+                      <p></p></td>
 				      <td class="summary"><p>User settings will need to address how to handle different contexts, such as aui-action="undo", for example, and which symbol to load for the setting. </p>
                       <p>A mechanism is needed to read users' settings and adapt the page. Open source script is available/ being worked on at <a href="http://rawgit.com/ayelet-seeman/COGA.personalisation">http://rawgit.com/ayelet-seeman/COGA.personalisation</a></p>
                       
@@ -1373,8 +1365,8 @@ Potential parts of a page
 				        
 				        </td>
 				      <td>Techniques for using correct semantics, and importing a script that adapts a web page.</td>
-				      <td><span property="xhv:role" resource="xhv:heading">Adding Context </span>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
+                      <p></p>
                       
                       <p>And adding context nodes.</p></td>
 				      <td><p>See above.</p>
@@ -1396,8 +1388,8 @@ Potential parts of a page
 				      <th scope="row">I need controls  to be consistently positioned on the screen.</th>
 				      <td>as the above</td>
 				      <td></td>
-				      <td><span property="xhv:role" resource="xhv:heading">Adding Context </span>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
+				      <td><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a> </span>
+                      <p></p></td>
 				      <td>Use of location as above with any element role, or context, or type.</td>
 				      <td></td>
 			        </tr>
@@ -1465,34 +1457,34 @@ Potential parts of a page
                     <th scope="row"><p>Understandable use of vocabulary, syntax, and other aspects of language.</p>
                       <p>Clear language</p>
                       <p> <a href="#Discussion7">more</a> </p></th>
-                    <td><p><strong>Understandable language</strong> (on instructions, labels, navigation, and important information)</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Instructions.2C_labels.2C_navigation_and_important_information_are_provided_with_a_clear_writing_style_that_includes:">§ link</a>)</p>
+                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
+                      <p></p>
                       <p>Level A and AA </p>
                       <p>also </p>
-                      <p><strong>Support personalization. </strong></p>
+                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
                       <p>--------</p>
                       <p><strong>To add</strong></p>
                       <p><strong>Provide clear language for all content.</strong></p>
                       <p>Level AAA</p>
                       
                       </td>
-                    <td><p><span property="xhv:role" resource="xhv:heading">2.3 Writing style</span></p>
+                    <td><p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">2.3 Writing style</a></span></p>
                       <p>Use a clear writing style.</p>
-                      <p>(<a  title="Permalink for 2.3 Writing style" aria-label="expand 2.3 Writing style" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style" class="expand">§ link</a>)</p>
-                      <p><span property="xhv:role" resource="xhv:heading">2.3.1 Be clear and to the point.</span></p>
-                      <p>(<a  title="Permalink for 2.3.1 Be clear and to the point" aria-label="expand 2.3.1 Be clear and to the point" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">§ link</a>)</p></td>
-                    <td><p><strong>aui-alternative</strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand values" href="">§ link</a>)                      </p>
-                      <p><strong>aui-easylang</strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand values" href="">§  link</a></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="">§</a> example)</p>
-                      <p><strong>Alternative is to use of EMMA</strong></p>
-                      <p> (<a  title="expand" class="expand" aria-label="expand example" href="">§</a> example)</p>
+                      <p></p>
+                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</span></p>
+                      <p></p></td>
+                    <td>
+                      <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#alternative-explanation">aui-alternative</a></strong></p>
+                      <p></p>
+                      <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#easylang-explanation">aui-easylang</a></strong></p>
+                      <p></p>
+                      <p><strong><a href="">Alternative is to use of EMMA</a></strong></p>
+                      <p></p>
                       <p><strong>Editors' Note:</strong> we still need to standardize the terms, such as for complexity.</p>
-                      <p><strong>aui-literal</strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand values" href="">§ link</a>)</p>
-                      <p><strong>Emotional ML</strong> can also be used to identify emotions in content (also for multimedia).</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="">§ link</a>)</p>
+                      <p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#literal-explanation">aui-literal</a></strong></p>
+                      <p></p>
+                      <p><strong><a href="">Emotional ML</a></strong> can also be used to identify emotions in content (also for multimedia).</p>
+                      <p></p>
                       	<p><strong>Editors' Note:</strong> do we need another way of adding emotions or sarcasm into content?</p></td>
                     <td><p>We need  user settings for:</p>
                       <p> 1. What type of COGA alternative text, e.g., <em>easylang numberfree vocab1000</em>.</p>
@@ -1520,26 +1512,26 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>Clarify implied information and provide unambiguous information.</p>
                       <p> <a href="#Discussion7">more</a> </p></th>
-                    <td><p><strong>Understandable language</strong> (on instructions, labels, navigation, and important information)</p>
+                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Understandable language</a></strong> (on instructions, labels, navigation, and important information)</p>
                       <p><span>Clear language in instructions</span> -  <strong>use literal text:</strong>(AA)</p>
                       <p>and </p>
                       <p>Each step in instructions are identified and <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-concrete-wording">concrete wording</a> is used.</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Instructions.2C_labels.2C_navigation_and_important_information_are_provided_with_a_clear_writing_style_that_includes:">§ link</a>) </p>
+                      <p> </p>
                       <p>------------</p>
-                      <p><strong>Support personalization.</strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Use_semantics_and_safe_standardized_techniques_that_enable_the_content_to_be_adapted_to_the_user_scenario_including_enabling_additional_support_and_personalization.">§</a> link) </p>
+                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+                      <p></p>
                       
                       <p><strong>Editors' Note:</strong> add to AAA.</p>
                       <p>Clarify implied information and clarify the emotional content. </p></td>
-                    <td><p>Use a clear Writing style.</p>
-                      <p>(<a  title="Permalink for 2.3 Writing style" aria-label="expand 2.3 Writing style" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style" class="expand">§ link</a>)</p>
-                      <p><span property="xhv:role" resource="xhv:heading">2.3.1 Be clear and to the point.</span></p>
-                      <p>(<a property="url" title="Permalink for 2.3.1 Be clear and to the point" aria-label="Permalink for 2.3.1 Be clear and to the point" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">§ link</a>)</p>
+                    <td><p>Use a clear <a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">Writing style</a>.</p>
+                      <p></p>
+                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#be-clear-and-to-the-point">2.3.1 Be clear and to the point</a>.</span></p>
+                      <p></p>
                       <h4 resource="#h-be-clear-and-to-the-point" id="h-be-clear-and-to-the-point2">..</h4>
-                      2.3.2 Give instructions clearly<span typeof="bookmark"><a property="url" title="Permalink for 2.3.2 Give instructions clearly" aria-label="Permalink for 2.3.2 Give instructions clearly" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#give-instructions-clearly"><span content="2.3.2 Give instructions clearly" property="title"></span></a></span>
-                      <p>(<a property="url" title="Permalink for 2.3.2 Give instructions clearly" aria-label="Permalink for 2.3.2 Give instructions clearly" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#give-instructions-clearly">§ link</a>)</p></td>
-                    <td><p><strong>aui-literal </strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand values" href="">§  link</a>)</p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#give-instructions-clearly">2.3.2 Give instructions clearly</a></p>
+                      <p></p></td>
+                    <td><p><strong><a href="https://w3c.github.io/personalization-semantics/help/index.html#literal-explanation">aui-literal</a></strong></p>
+                      <p></p>
                       <p><strong>Emotional ML</strong> can also be used to identify emotions in content (also for multimedia).</p>
                       <p><strong>Editors' Note:</strong> do we need another way of adding the emotions or sarcasm into content?</p>
                       <p>[[EMMA]] can also be used in content.</p></td>
@@ -1570,7 +1562,7 @@ Potential parts of a page
                       </ul>
                       <p>------</p>
                       <p>Also see</p>
-                      <strong>Support personalization.</strong>
+                      <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong>
                       
                       <h5 id="provided_content2">..</h5>
                       
@@ -1578,15 +1570,15 @@ Potential parts of a page
                     <td><p>Ability to have mathematical notation with text to speech to aid understanding.</p>
                       <p>Use of synchronized highlighting of complex graphics and formula with speech. </p>
                       <p>Associate maths, sections of math, and sections of complex items, with explanations.</p>
-                      <h5 resource="#h-relative-values" id="h-relative-values2"><span property="xhv:role" resource="xhv:heading">2.6.3.5 Relative values</span></h5>
+                      <h5 resource="#h-relative-values" id="h-relative-values2"><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#relative-values">2.6.3.5 Relative values</a></span></h5>
                       <p><strong>Editors' Note:</strong> this is not clear.</p>
-                      <p>(<a property="url" title="Permalink for 2.6.3.5 Relative values" aria-label="Permalink for 2.6.3.5 Relative values" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#relative-values">§  link</a> )</p>
-                      <p><span property="xhv:role" resource="xhv:heading">Use semantics to provide extra help.</span></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="">§ link</a>) </p>
+                      <p></p>
+                      <p><span property="xhv:role" resource="xhv:heading"><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#relative-values">Use semantics to provide extra help</a>.</span></p>
+                      <p></p>
                       
                       <p>Explain mathematical concepts with non-mathematical language. For example &quot;change 90% agree&quot;, to &quot;most users (90%) agree&quot;.</p></td>
-                    <td><p>aui-numberfree</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="">§ link</a>)</p></td>
+                    <td><p><a href="https://w3c.github.io/personalization-semantics/help/index.html#numberfree-explanation">aui-numberfree</a></p>
+                      <p></p></td>
                     <td><p>User settings must identify:</p>
                       <p>1. when a user prefers content with less numerical content and prefers words;</p>
                       <p>2. when a user prefers content without dependence on math concepts;</p>
@@ -1606,12 +1598,12 @@ Potential parts of a page
                     <th scope="row">Support for slow readers</th>
                     <td><p><strong>Manageable blocks of information:</strong></p>
                       <p><strong>Understandable language</strong></p>
-                      <p><strong>clear structure and relationships</strong>. </p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/extension/index.html#Provide_a_clear_structure_that_includes:">§ link</a>)</p>
-                      <p> <strong>When there is a barrier</strong> between content and users, which requires additional cognitive function, an alternative is provided that does not require additional cognitive function.</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/extension/index.html#When_there_is_a_barrier_between_the_content_and_the_user_that_requires_additional_cognitive_function_an_alternative_is_provided_that_does_not_require_additional_cognitive_function">§ link</a>)</p>
-                      <p><strong>Support personalization.</strong></p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/extension/index.html#Use_semantics_and_safe_standardized_techniques_that_enable_the_content_to_be_adapted_to_the_user_scenario_including_enabling_additional_support_and_personalization.">§ link</a>)</p>
+                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#Providea%20clearstructureandlayout">clear structure and relationships</a></strong>.</p>
+                      <p></p>
+                      <p> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">When there is a barrier</strong>, between content and users, which requires additional cognitive function,  an alternative is provided that does not require additional cognitive function.</a></p>
+                      <p></p>
+                      <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+                      <p></p>
                       <p><strong>clear text and voice</strong></p>
                       <p><strong>Critical features </strong>and important information are above the fold on most users' devices, and are accentuated in the preferred modalities of users, or they appear before other main content. </p>
                       <p><strong>Clear headings</strong></p>
@@ -1620,12 +1612,12 @@ Potential parts of a page
                       <p>Provide content and information that help users understand <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-complex-information">complex information</a>, long documents, numerical information, forms, and nonstandard controls. </p>
                       <p>Where an understanding of math is not a primary requirement for using content, reinforce numbers with non-numerical values. </p>
                       <p><strong>Editors' Note: </strong> ensure sufficient techniques, as in the next volume.</p></td>
-                    <td><p>Use a clear <a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">writing style</a>.(<a  title="Permalink for 2.3 Writing style" aria-label="expand 2.3 Writing style" href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style" class="expand">§ link</a>)</p>
-                      <p>Use a<strong> clear  structure. </strong></p>
-                      <p>(<a  title="Permalink for 2.3 Writing style" aria-label="expand 2.3 Writing style" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Provide_a_clear_structure_that_includes:">§ link</a>)</p>
-                      <p>2.5 Help meaning</p>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-meaning">§ link</a>)</p>
-                      <p><strong>Editors' Note: </strong> ensure sufficient techniques.</p>E
+                    <td><p>Use a clear <a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#writing-style">writing style</a>.</p>
+                      <p>Use a<strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#Providea%20clearstructureandlayout"> clear structure</a></strong>.</p>
+                      <p></p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#help-meaning">2.5 Help meaning</a></p>
+                      <p></p>
+                      <p><strong>Editors' Note: </strong> ensure sufficient techniques.</p>
                       <p>For icons and jargon:</p>
                       <ul>
                         <li>All icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> have short explanations available. Where a standard mechanism exists for the platform or technologies, it should be used (COGA Techniques 2.7.) (<strong>Editors' Note:</strong> removed to technique: Short tooltips on all icons and <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-jargon">jargon</a> that clarify the meaning are provided.)</li>
@@ -1635,20 +1627,20 @@ Potential parts of a page
                         <li>For pieces of content with fewer than 200 words, headings may act as summaries. </li>
                         <li>The content owner identifies at least two <a data-link-type="dfn" href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-keywords-that-aid-comprehension">keywords that aid comprehension</a> for users. Keywords are programmatically determinable, and emphasized in the  preferred modalities of users. </li>
                       </ol>
-                      <p>For key content and callout boxes:</p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For key content and call out boxes</a>:</p>
                       <ul>
-                        <li>Symbols are provided to help users identify key content including: types of contact information, main functions, warnings, and key points. Where a standard mechanism exists for   the platform or technologies, it should be used. </li>
+                        <li>Symbols are provided to help users identify key content including: types of contact information, main functions, warnings, and key points. Where a standard mechanism exists for the platform or technologies, it should be used. </li>
                       </ul>
-                      <p>For events</p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For events</a>:</p>
                       <ul>
-                        <li>Enable users to set a reminder for   date and time sensitive events. Reminders should be set only at the   users request. Users should be able to personalize the reminder   method. Where a standard mechanism exists for the platform or   technologies, it should be used</li>
+                        <li>Enable users to set a reminder for   date and time sensitive events. Reminders should be set only at the   users request. Users should be able to personalize the reminder   method. Where a standard mechanism exists for the platform or technologies, it should be used</li>
                       </ul>
-                      <p>For  forms and nonstandard controls</p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#provided content">For forms and nonstandard controls</a></p>
                       <ol>
-                        <li>Where a standard mechanism  for the   platform or technologies exist for context sensitive help, it should be   used. (Simple search forms are excluded.)</li>
+                        <li>Where a standard mechanism for the platform or technologies exist for context sensitive help, it should be   used. (Simple search forms are excluded.)</li>
                         <li>Instructions should be available for nonstandard controls. </li>
                       </ol>
-                      <p>(<a  title="expand" class="expand" aria-label="expand " href="https://rawgit.com/w3c/COGA/master/extension/index.html#Support_is_provided_that_help_users_understand_the_content.2C_that_includes:">§ link</a>)</p>
+                      <p></p>
                       <p>And others...</p></td>
                     <td><p>As above</p>
                       <p>Also, having less content is helpful for slow readers,</p>
@@ -1685,7 +1677,7 @@ Potential parts of a page
                     </ul>
                     </td>
                     <td></td>
-                    <td>adding context</td>
+                    <td><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></td>
                     <td><p>Ensure symbols can be are associated with types for call out boxes.</p>
                       <p>Identify preferred symbol sets for concept mapping.</p>
                       
@@ -1772,8 +1764,8 @@ Potential parts of a page
                       <p> <a href="#Discussion8">more</a> </p>
                       
                     </th>
-                    <td><p><strong>Accessible authentication</strong></p>
-                    <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#When_there_is_a_barrier_between_the_content_and_the_user_that_requires_additional_abilities_an_alternative_is_provided_that_does_not_require_additional_abilities.">(§ link</a>)</p>
+                    <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">Accessible authentication</a></strong></p>
+                    <p></p>
                     <p>and voice over IP criteria on barriers (<strong>Editors' Note:</strong> to be added)</p>
                     
                     <p>----------------------------</p>
@@ -1784,7 +1776,7 @@ Potential parts of a page
                     <h4 id="layout"><strong> Clear and understandable layout  </strong></h4>
                     <h4 id="familiar"><strong>A familiar design </strong></h4>
 <strong>Critical features </strong>
-                    <p><strong>Support <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-personalization">personalization</a>. </strong></p>
+                    <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>. </strong></p>
                     <h5 id="semantics2">..</h5>
                     
                     
@@ -1792,13 +1784,13 @@ Potential parts of a page
                     
                     </td>
                     <td> </td>
-                    <td><span property="xhv:role" resource="xhv:heading">Simplification</span>
-                      <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-simplification">§ link</a>)</p>
+                    <td><span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a></span>
+                      <p></p>
                        
-                      <p><span property="xhv:role" resource="xhv:heading">Adding Context </span>
+                      <p><span property="xhv:role" resource="xhv:heading"><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></span>
                       </p>
-                    <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-adding-context">§ link</a>)</p></td>
-                    <td> Settings for simplification and adding context as above.</td>
+                    <p></p></td>
+                    <td>Settings for simplification and adding context as above.</td>
                     <td> </td>
                   </tr>
                   <tr>
@@ -1806,11 +1798,11 @@ Potential parts of a page
                     <td>As above.
                       <p>and</p>
                     <p><strong>Help</strong></p>
-                    <p><strong>Support <a href="https://rawgit.com/w3c/COGA/master/extension/index.html#dfn-personalization">personalization</a>:  </strong></p>
+                    <p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>:  </strong></p>
                     <p>Where the number of steps in a process can be reduced, users can control the tradeoff between function and simplification.</p></td>
-                    <td>p><strong>Editors' Note:</strong> to be completed.</p></td>
-                    <td><span property="xhv:role" resource="xhv:heading">Simplification</span>
-                    <p>(<a  title="expand" class="expand" aria-label="expand example" href="https://rawgit.com/w3c/COGA/master/gap-analysis/semantics.html#h-simplification">§ link</a>)</p></td>
+                    <td><p><strong>Editors' Note:</strong> to be completed.</p></td>
+                    <td><span property="xhv:role" resource="xhv:heading"><a href="https://www.w3.org/TR/personalization-semantics-content-1.0/#simplification-explanation">Simplification</a></span>
+                    <p></p></td>
                     <td> Support for simplification as above, 
                                         <p><strong>Editors' Note:</strong> to be completed.</p></td>
                     <td><p><strong>Editors' Note:</strong> to be completed.</p></td>
@@ -1818,8 +1810,8 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>I need simple-to-navigate menu systems. </p>
                       </th>
-                    <td><span property="xhv:role" resource="xhv:heading"> <strong>Clear language :</strong></span>
-                      <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes">§ link</a>)</p>
+                    <td><span property="xhv:role" resource="xhv:heading"> <strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#instructions">Clear language</a>:</strong></span>
+                      <p resource="#h-instructions-labels-navigation-and-important-information-are-provided-with-a-clear-writing-style-that-includes"></p>
                       <p>See: In menus with sub menus: </p>
                       <ol>
                         <li>the text of each main menu item is easy to understand. </li>
@@ -1829,8 +1821,8 @@ Potential parts of a page
                         <li>each sub-menu item is clearly associated with a main menu item under which it falls. (This can be due to being an industry or a platform default.) </li>
                       </ol>
                       <p>) </p>
-                      <p><span property="xhv:role" resource="xhv:heading"><strong>Help</strong></span></p>
-                      <p> (<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#h-support-is-provided-that-help-users-understand-the-content-that-includes2">§ link</a>) </p>
+                      <p><span property="xhv:role" resource="xhv:heading"><strong><a href="the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Help</a></strong></span></p>
+                      <p> </p>
                       <h4 resource="#h-support-is-provided-that-help-users-understand-the-content-that-includes" id="h-support-is-provided-that-help-users-understand-the-content-that-includes4">..</h4>
                       
                     <p><strong>Editors' Note:</strong> further work?</p></td>
@@ -1842,16 +1834,16 @@ Potential parts of a page
                   <tr>
                     <th scope="row"><p>I need simple-to-navigate voice-menu systems.</p>
                       <p><a href="#Discussion8">more</a></p></th>
-                    <td><p>1.4.4 When there is a <strong>barrier</strong> between content and users, which requires additional abilities, an alternative is provided that does not require additional abilities.</p>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#When_there_is_a_barrier_between_the_content_and_the_user_that_requires_additional_abilities_an_alternative_is_provided_that_does_not_require_additional_abilities.">(§ link</a>)</p>
+                    <td><p><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#barrier">1.4.4 When there is a barrier between content and users, which requires additional abilities, an alternative is provided that does not require additional abilities</a>.</p>
+                      <p></p>
                     <p><strong>Editors' Note:</strong> add best practices?</p>
                     </td>
-                    <td><p>Human help should be one click away. Example: use available standards to get human help, such as using the 0 digit on voice menu systems.</p>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">(§ link)</a></p>
+                    <td><p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Providehumanhelp">Human help</a></p>
+                      <p></p>
                       <p><strong>Editors' Note:</strong> can we add a method to repeat a last option?</p>
                       
-                      <p>Minimize cognitive skills required to use content when there is a known alternative.</p>
-                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Minimizethecognitiveskills">(§ link)</a></p>
+                      <p><a href="https://rawgit.com/w3c/COGA/master/techniques/index.html#Minimizethecognitiveskills">Minimize the cognitive skills required to use content when there is a known alternative</a>.</p>
+                      <p></p>
                       
                       </td>
                     <td>Can semantics help? Operators and functions, such as main menu, undo, back, and repeat a last option, are standardized. </td>
@@ -1910,10 +1902,10 @@ Potential parts of a page
     <tr>
       <th scope="row"><p>root option for simplicity - let me balance complexity and speed.</p>
       <p> <a href="#Discussion7">more</a> </p></th>
-      <td><p><strong>Support personalization.</strong></p>
-        <p>. </p>
-        <p>Where the number of steps in a process can be reduced, enable users   to control the trade off between function and simplification.</p>
-        <p>(<a  title="expand" class="expand" aria-label="expand 1.4.3" href="https://rawgit.com/w3c/COGA/master/extension/index.html#Use_semantics_and_safe_standardized_techniques_that_enable_the_content_to_be_adapted_to_the_user_scenario_including_enabling_additional_support_and_personalization.">§</a> link) </p></td>
+      <td><p><strong><a href="https://rawgit.com/w3c/COGA/master/extension/index.html#semantics">Support personalization</a>.</strong></p>
+        <p> </p>
+        <p>Where the number of steps in a process can be reduced, enable users to control the trade off between function and simplification.</p>
+        <p></p></td>
       <td><p><strong>Editors' Note:</strong> to be completed.</p></td>
       <td>
       <p><strong>Editors' Note:</strong> add for GPS.</p></td>

--- a/gap-analysis/table.html
+++ b/gap-analysis/table.html
@@ -690,7 +690,7 @@ Always    open</p>
 				        
 				        
 				        
-				        <p><a href="https://w3c.github.io/coga/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available-spoken-feedback-should-be-a-user-selectable-option">Support is provided that helps users understand the content</a>, which includes: </p>
+				        <p><a href="https://w3c.github.io/coga/extension/index.html#the-success-or-failure-of-every-action-should-be-clearly-indicated-to-the-user-and-visual-rapid-feedback-should-be-available.-spoken-feedback-should-be-a-user-selectable-option.x">Support is provided that helps users understand the content</a>, which includes: </p>
 				        
 				        <p>Level A</p>
 				        <p>--------</p>
@@ -936,7 +936,7 @@ aui-hidden="true"&gt;</pre>
 				        <p>--------</p>
 				        <p><strong>Editors' Note:</strong> to add</p>
 			          </td>
-				      <td><a href="https://w3c.github.io/coga/techniques/index.html#use-clear-visual-affordances">Use clear visual affordances</a>.
+				      <td><a href="https://w3c.github.io/coga/techniques/index.html#use-clear-visual-affordances.x">Use clear visual affordances</a>.
 			          <p></p></td>
 				      <td><strong><a  title="expand" class="expand" aria-label="expand example" href="https://www.w3.org/TR/personalization-semantics-content-1.0/#use_case_adding_context">Adding Context</a></strong>
                         


### PR DESCRIPTION
changed the URI with W3C.github.io, and clean the invalid properties.