### PR TITLE
Update design.html - fix HTML5 link in 4.9.4.5

### DIFF
--- a/content-usable/design.html
+++ b/content-usable/design.html
@@ -4046,7 +4046,7 @@
               </ol>
               <p><span class="avoid"></span><strong>Avoid:</strong></p>
               <ol>
-              <li>Forms that do not support [[HTML5] autocomplete.</li>
+              <li>Forms that do not support [HTML5] autocomplete.</li>
               <li>Default fonts that are not clear or readable such as a cartoon font or gothic.</li>
               <li>Pages that can not easily be personalized.</li>
               </ol>


### PR DESCRIPTION
Removing unintentional character in 4.9.4.5 Examples, which broke the HTML5 link