### PR TITLE
Semantic markup in sum, visually styled as paras

### DIFF
--- a/content-usable/index.html
+++ b/content-usable/index.html
@@ -178,7 +178,26 @@
 			list-style-type: none;
 			margin-left: 1.5em;
 		}
-
+		#summary .imagelist h2 {
+			color: black;
+			display: inline;
+			font-size: 1em;
+			font-weight: bold;
+			padding-right: 0.3em;
+		}
+		#summary .imagelist div.see-also {
+			margin: 1em 0;
+		}
+		#summary .imagelist ul {
+			display: inline;
+			margin-left:0;
+			padding-left:0;
+		}
+		#summary .imagelist ul li {
+			display: inline;
+			list-style: none;
+			padding-left: .3em;
+		}
     </style>
 
     <link href="../common/common.css" rel="stylesheet" type="text/css" />
@@ -214,47 +233,47 @@
 <p>To help web content providers meet the needs of people with cognitive and learning disabilities we have identified the following key topics:</p>
 <ol class="imagelist">
 <li><img src="./img/StartHere.svg" alt="" width="40" height="40" />
-<strong>Help users understand what things are and how to use them.</strong> Use things that are familiar to the user so that they do not have to learn new icons, symbols, terms, or design patterns. People with cognitive and learning disabilities often need common behavior and design patterns. For example, they may know the standard convention for links (underlined and blue for unvisited; purple for visited).
-	<p>See also: <a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them">user needs</a>, <a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them-0">design patterns</a>, <a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 1.</p>
+<h2>Help users understand what things are and how to use them.</h2> Use things that are familiar to the user so that they do not have to learn new icons, symbols, terms, or design patterns. People with cognitive and learning disabilities often need common behavior and design patterns. For example, they may know the standard convention for links (underlined and blue for unvisited; purple for visited).
+	<div class="see-also">See also:</div><ul><li><a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them">user needs</a>,</li><li><a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them-0">design patterns</a>,</li><li><a href="#objective-1-help-users-understand-what-things-are-and-how-to-use-them-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 1.</li></ul>
 </li>
 <li><img src="./img/find.svg" alt="" width="40" height="40" />
-<strong>Help users find what they need.</strong> Navigating a system should be easy. Have a clear and easy to follow layout with visual cues, such as icons. Clear headings, boundaries, and regions also helps people understand the page design.
-<p>See also: <a href="#objective-2-help-users-find-what-they-need">user needs</a>, <a href="#objective-2-help-users-find-what-they-need-0">design patterns</a>, <a href="#objective-2-help-users-find-what-they-need-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 2.</p>
+<h2>Help users find what they need.</h2> Navigating a system should be easy. Have a clear and easy to follow layout with visual cues, such as icons. Clear headings, boundaries, and regions also helps people understand the page design.
+	<div class="see-also">See also:</div><ul><li><a href="#objective-2-help-users-find-what-they-need">user needs</a>,</li><li><a href="#objective-2-help-users-find-what-they-need-0">design patterns</a>,</li><li><a href="#objective-2-help-users-find-what-they-need-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 2.</li></ul>
 </li>
 	
 <li><img src="./img/clear-text.svg" alt="" width="40" height="40" />
-<strong>Use clear content (text, images and media).</strong> This includes easy words, short sentences and blocks of text, clear images, and easy to understand video.<p>See also: <a href="#objective-3-use-clear-and-understandable-content">user needs</a>, <a href="#objective-3-use-clear-and-understandable-content-0">design patterns</a>, <a href="#objective-3-use-clear-and-understandable-content-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 3.</p>
+<h2>Use clear content (text, images and media).</h2> This includes easy words, short sentences and blocks of text, clear images, and easy to understand video.<div class="see-also">See also:</div><ul><li><a href="#objective-3-use-clear-and-understandable-content">user needs</a>,</li><li><a href="#objective-3-use-clear-and-understandable-content-0">design patterns</a>,</li><li><a href="#objective-3-use-clear-and-understandable-content-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 3.</li></ul>
 </li>
 	
 <li><img src="./img/glass.svg" alt="" width="40" height="40" />
-<strong>Help users avoid mistakes.</strong> A good design makes errors less likely. Do not ask the user for more things than you need! When errors occur, the user should find it easy to correct them.
-<p>See also: <a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them">user needs</a>, <a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them-0">design patterns</a>, <a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 4.</p>
+<h2>Help users avoid mistakes.</h2> A good design makes errors less likely. Do not ask the user for more things than you need! When errors occur, the user should find it easy to correct them.
+<div class="see-also">See also:</div><ul><li><a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them">user needs</a>,</li><li><a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them-0">design patterns</a>,</li><li><a href="#objective-4-help-users-avoid-mistakes-and-know-how-to-correct-them-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 4.</li></ul>
 </li>
 <li><img src="./img/light.svg" alt="" width="40" height="40" />
-<strong>Help users focus.</strong> Avoid distracting the user from their task. If the user does get distracted, headings and breadcrumbs can help orientate the user and help the user restore the context when it is lost. Providing linked breadcrumbs can help the user undo mistakes.
-<p>See also: <a href="#objective-5-help-users-focus">user needs</a>, <a href="#objective-5-help-users-focus-0">design patterns</a>, <a href="#objective-5-help-users-focus-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 5.</p>
+<h2>Help users focus.</h2> Avoid distracting the user from their task. If the user does get distracted, headings and breadcrumbs can help orientate the user and help the user restore the context when it is lost. Providing linked breadcrumbs can help the user undo mistakes.
+<div class="see-also">See also:</div><ul><li><a href="#objective-5-help-users-focus">user needs</a>,</li><li><a href="#objective-5-help-users-focus-0">design patterns</a>,</li><li><a href="#objective-5-help-users-focus-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 5.</li></ul>
 </li>
 <li><img src="./img/memory.svg" alt="" width="40" height="40" />
-<strong>Ensure processes do not rely on memory.</strong> Memory barriers stop people with cognitive disabilities from using content. This includes long passwords to log in and voice menus that involve remembering a specific number or term. Make sure there is an easier option for people who need it.
-<p>See also: <a href="#objective-6-ensure-processes-do-not-rely-on-memory">user needs</a>, <a href="#objective-6-ensure-processes-do-not-rely-on-memory-0">design patterns</a>, <a href="#objective-6-ensure-processes-do-not-rely-on-memory-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 6.</p>
+<h2>Ensure processes do not rely on memory.</h2> Memory barriers stop people with cognitive disabilities from using content. This includes long passwords to log in and voice menus that involve remembering a specific number or term. Make sure there is an easier option for people who need it.
+<div class="see-also">See also:</div><ul><li><a href="#objective-6-ensure-processes-do-not-rely-on-memory">user needs</a>,</li><li><a href="#objective-6-ensure-processes-do-not-rely-on-memory-0">design patterns</a>,</li><li><a href="#objective-6-ensure-processes-do-not-rely-on-memory-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 6.</li></ul>
 </li>
 <li><img src="./img/support.svg" alt="" width="40" height="40" /><strong> Provide help and support</strong>. This includes:
-<strong>making it easy to get human help.</strong> If users have difficulty sending feedback, then you will never know if they are able to use the content or when they are experiencing problems. In addition,
+<h2>making it easy to get human help.</h2> If users have difficulty sending feedback, then you will never know if they are able to use the content or when they are experiencing problems. In addition,
 <strong>support different ways to understand content.</strong> Graphics, summaries of long documents, adding icons to headings and links, and alternatives for numbers are all examples of extra help and support.
-<p>See also: <a href="#objective-7-provide-help-and-support">user needs</a>, <a href="#objective-7-provide-help-and-support-0">design patterns</a>, <a href="#objective-7-provide-help-and-support-1">mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 7.</p>
+<div class="see-also">See also:</div><ul><li><a href="#objective-7-provide-help-and-support">user needs</a>,</li><li><a href="#objective-7-provide-help-and-support-0">design patterns</a>,</li><li><a href="#objective-7-provide-help-and-support-1">mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 7.</li></ul>
 </li>
 <li><img src="./img/tools.svg" alt="" width="40" height="40" />
-<strong>Support adaptation and personalization.</strong> People with cognitive and learning disabilities often use add-ons or extensions as assistive technology. Sometimes, extra support requires minimal effort from the user via personalization that allows the user to select preferred options from a set of alternatives. Support personalization when you can. Do not disable add-ons and extensions!
-<p>See also: <a href="#objective-8-support-adaptation-and-personalization">user needs</a>, <a href="#objective-8-support-adaptation-and-personalization-0">design patterns</a>, <a href="#objective-8-support-adaptation-and-personalization"> mappings to scenarios</a>, and <a href="#Building_in_the_user">user testing</a> for objective 8.</p>
+<h2>Support adaptation and personalization.</h2> People with cognitive and learning disabilities often use add-ons or extensions as assistive technology. Sometimes, extra support requires minimal effort from the user via personalization that allows the user to select preferred options from a set of alternatives. Support personalization when you can. Do not disable add-ons and extensions!
+<div class="see-also">See also:</div><ul><li><a href="#objective-8-support-adaptation-and-personalization">user needs</a>,</li><li><a href="#objective-8-support-adaptation-and-personalization-0">design patterns</a>,</li><li><a href="#objective-8-support-adaptation-and-personalization"> mappings to scenarios</a>,</li><li>and <a href="#Building_in_the_user">user testing</a> for objective 8.</li></ul>
 </li>
 <li><img src="./img/users.svg" alt="" width="40" height="40" />
-<strong>Test with real users!</strong> Involve people with disabilities in the research, design, and development process. They're the experts in what works for them. This includes involving people with cognitive and learning disabilities in:
+<h2>Test with real users!</h2> Involve people with disabilities in the research, design, and development process. They're the experts in what works for them. This includes involving people with cognitive and learning disabilities in:
 <ul>
 <li>focus groups.</li>
 <li>usability tests, and</li>
 <li>the design and research team.</li>
 </ul>
-<p>See also: <a href="#working-with-users-with-cognitive-and-learning-disabilities">working with users with cognitive and learning disabilities</a> and <a href="#Building_in_the_user">section 5</a>.</p>
+<div class="see-also">See also:</div><ul><li><a href="#working-with-users-with-cognitive-and-learning-disabilities">working with users with cognitive and learning disabilities</a></li><li>and <a href="#Building_in_the_user">section 5</a>.</li></ul>
 </li>
 </ol>
 


### PR DESCRIPTION
Added CSS and semantic markup to the summary so that the summary uses headers and lists, but displays as the simple list that it was before.