### PR TITLE
Update o3p06-format-punctuation.html

### DIFF
--- a/design-guide/o3p01-clear-words.html
+++ b/design-guide/o3p01-clear-words.html
@@ -142,7 +142,7 @@ sidebar:
     </li>
     <li>
       Acronyms that are not in common use, are explained the first time they are
-      used, and are in an acronym tag with a title after that.
+      used, and are in an abbr tag (element) with a title after that.
     </li>
     <li>Jargon that is avoided or explained.</li>
   </ol>

--- a/design-guide/o3p06-format-punctuation.html
+++ b/design-guide/o3p06-format-punctuation.html
@@ -91,7 +91,7 @@ sidebar:
   </p>
   <p>
     <strong>Avoid the use of Roman Numerals and unfamiliar symbols</strong>
-    in text were possible. These can confuse readers and are likely to be read
+    in text where possible. These can confuse readers and are likely to be read
     incorrectly by text-to-speech tools. If these symbols are necessary then
     ensure they are marked up correctly, using techniques such as MathML and
     abbreviation expansions to provide additional support. Roman Numerals should


### PR DESCRIPTION
1. Text of “"Avoid the use of Roman Numerals and unfamiliar symbols in text were possible. " should be “..where possible”
2. acronym element (tag) is not appropriate
# COGA- Pull Request Template
## Summary:
- File(s) added/changed: ---- Update o3p06-format-punctuation.html
- Short description of changes: ---- Replaced 'were' with "where" (editorial), updated acronym element text
- Notes (if needed): ----   issue #315, 314
##Source
- where is it from such as google docs url : ---- https://docs.google.com/document/d/1FkyRIP3CAuZ-JAazUOAUI64TYCrEfOkKSeBg94mMOkg/edit?pli=1&resourcekey=0-HM4QyycKbkfCwWAXzIymrw&tab=t.0
- when was it aproved such as meating minutes : ---- Text fixes like this explicitly approved by group
## Did this break anything?
- [x ] No
- [ ] Yes
## Type of change
- [ ]  New section
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Stucture change
- [ x]  Super small fix (Corrected a typo, removed a comment, etc.)
- [x]  Skip all the other stuff and briefly explain the fix.
## Code Quality Checklist:
- [x ]  I checked the stucture is the same as the original
- [ ]  I checked the format is the same as the original 
- [ ]  pargraph before and after loads corectly without changes to the font or format

## Editorial Quality Checklist:
- [ ]  I did not check the editorial aspects
- [ ]  grammer and capitalization
- [ ]  short sentences and easy words
- [ ]  Present tense and active voicing
