### PR TITLE
Update o4p09-data-loss.html

### DIFF
--- a/design-guide/o4p09-data-loss.html
+++ b/design-guide/o4p09-data-loss.html
@@ -52,7 +52,7 @@ sidebar:
     Timed events can present significant barriers for users with
     <a>cognitive and learning disabilities</a>. These users may require more
     time to read content or to perform functions, such as completing an online
-    form. They may need to read help information or look at notes.They may also need
+    form. They may need to read help information or look at notes. They may also need
     additional time to look up the information required to complete a transaction.
   </p>
  
@@ -74,12 +74,6 @@ sidebar:
    For example, a user is completing an online process for reserving a hotel room and purchasing a plane ticket. 
    They become overwhelmed with the amount of instructions and data input required to complete the process. 
    The user cannot complete the process in one sitting, and takes a break. Their information and work done so far is lost.
-  </p>
-  <p>
-    Users’ cognitive skills may diminish as they get tired. They then must stop
-    the task for that day. When users know that their data won’t be lost, they
-    can recover from mental fatigue and return to successfully complete the
-    task.
   </p>
   <p>
     Mental health disabilities can also cause cognitive challenges,  such as memory problems, trouble staying focused,
@@ -129,7 +123,7 @@ sidebar:
           example: In an auction, there is a time limit on the amount of time a
           user has to submit a bid. At the start of the task, the user is warned
           about the time limit, and how long they have until the time ends. At the start of
-          the task/process, also tell the users what they need to do to extend the time out 
+          the task/process, also tell the users what they need to do to extend the timeout 
           as it may take them time to read the notice.
 
         </li>


### PR DESCRIPTION
-Added space after full stop.
-Changed time out to timeout.
-Removed the redundant para.
[Resolved issues from comment-
How it Helps," first paragraph: Add a space between the last two sentences: "...look at notes.[SPACE MISSING]They may also..." "How it Helps," fifth paragraph: Remove the paragraph that begins "Users' cognitive skills may diminish..." It is old content that has been woven in elsewhere in this section, so this fifth paragraph is redundant.

"Examples," last sentence in 3A: Remove the extra space so "time out" becomes "timeout." Here's where it appears: "...extend the time[REMOVE THIS SPACE]out as it may take..." ]

# COGA- Pull Request Template
## Summary:
- File(s) added/changed: ----
- Short description of changes: ----
- Notes (if needed): ----
##Source
- where is it from such as google docs url : ----
- when was it aproved such as meating minutes : ----
## Did this break anything?
- [x] No
- [ ] Yes
## Type of change
- [ ]  New section
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Stucture change
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [x]  Skip all the other stuff and briefly explain the fix.
## Code Quality Checklist:
- [ ]  I checked the stucture is the same as the original
- [x]  I checked the format is the same as the original 
- [ ]  pargraph before and after loads corectly without changes to the font or format

## Editorial Quality Checklist:
- [ ]  I did not check the editorial aspects
- [ ]  grammer and capitalization
- [ ]  short sentences and easy words
- [ ]  Present tense and active voicing
