### PR TITLE
Fix HTML link to google doc  in symbols-non-verbal.html

### DIFF
--- a/issue-papers/symbols-non-verbal.html
+++ b/issue-papers/symbols-non-verbal.html
@@ -1,7 +1,7 @@
 <section>
 	<h1>Symbol users with Speech, Language and Literacy Difficulties</h1>
 <p class="ednote" title="Out of date">
-This draft is out of date, an update that addresses new research and new technologies is being worked on at <a href=”https://docs.google.com/document/d/1AlhQVd7aBrxxJA_h9zw3OPczBJUmZ9qV-d4M7viUKpM/edit#heading=h.bc4vqyklmnk0”>Symbol users with Speech, Language and Literacy Difficulties</a>. </p>
+This draft is out of date, an update that addresses new research and new technologies is being worked on at <a href="https://docs.google.com/document/d/1AlhQVd7aBrxxJA_h9zw3OPczBJUmZ9qV-d4M7viUKpM/edit#heading=h.bc4vqyklmnk0">Symbol users with Speech, Language and Literacy Difficulties</a>. </p>
 	<section>
         <h2>Introduction</h2>
         <p>Voice Output Communication Aids (VOCAs) are devices that have been developed to allow pictures, symbols or words to be used with speech synthesis. The devices may be specialist items with built in systems carrying the symbols. They may also be a generic computer, tablet or mobile with specialist software or apps. The symbols are activated by single or multiple touches, eyes dwelling on a chosen image or manual use of a keyboard or switches. An external input device usually allows for step by step scanning up and down rows and columns of symbols on a grid. Symbols and word choices are personalised to suit the user, representing known objects, actions and happenings.</p>


### PR DESCRIPTION
# COGA- Pull Request Template
## Summary:
- File(s) added/changed:symbols-non-verbal.html
- Short description of changes:  quotes in link to update were wrong format
- Notes (if needed): ----
##Source
- where is it from such as google docs url :na 
- when was it aproved such as meating minutes : just a debug
## Did this break anything?
- [- ] No
- [ ] Yes
## Type of change
- [ ]  New section
- [- ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Stucture change
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [x]  Skip all the other stuff and briefly explain the fix.
## Code Quality Checklist:
- [- ]  I checked the stucture is the same as the original
- [- ]  I checked the format is the same as the original 
- [- ]  pargraph before and after loads corectly without changes to the font or format

## Editorial Quality Checklist:
- [- ]  I did not check the editorial aspects
- [ ]  grammer and capitalization
- [ ]  short sentences and easy words
- [ ]  Present tense and active voicing
